### PR TITLE
Add setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,24 @@
+#!/usr/bin/env python
+
+from setuptools import setup
+
+setup(name='fluent',
+      version='0.3',
+      description='Python fluent library',
+      author='Staś Małolepszy',
+      author_email='stas@mozilla.com',
+      license='APL 2',
+      url='https://github.com/projectfluent/python-fluent',
+      classifiers=[
+            'Development Status :: 3 - Alpha',
+            'Intended Audience :: Developers',
+            'License :: OSI Approved :: Apache Software License',
+            'Programming Language :: Python :: 2.6',
+            'Programming Language :: Python :: 2.7',
+            'Programming Language :: Python :: 3.5',
+      ],
+      packages=['fluent', 'fluent.syntax'],
+      install_requires=[
+          'six'
+      ]
+      )


### PR DESCRIPTION
Adding `setup.py` (mostly copied from https://github.com/l20n/python-l20n/) to be able to pip install the library.

I need this in Pontoon, so I currently use my fork. Other people will need it, too.