### PR TITLE
Introduce fluent.syntax.ast.from_json

### DIFF
--- a/fluent/syntax/ast.py
+++ b/fluent/syntax/ast.py
@@ -1,12 +1,27 @@
 from __future__ import unicode_literals
+import sys
 import json
 
 
 def to_json(value):
     if isinstance(value, Node):
-        return value.toJSON()
+        return value.to_json()
     if isinstance(value, list):
         return list(map(to_json, value))
+    else:
+        return value
+
+
+def from_json(value):
+    if isinstance(value, dict):
+        cls = getattr(sys.modules[__name__], value["type"])
+        args = {
+            k: from_json(v)
+            for k, v in value.items() if k != "type"
+        }
+        return cls(**args)
+    if isinstance(value, list):
+        return list(map(from_json, value))
     else:
         return value
 
@@ -41,7 +56,7 @@ class Node(object):
 
         return fun(node)
 
-    def toJSON(self):
+    def to_json(self):
         obj = {
             name: to_json(value)
             for name, value in vars(self).items()
@@ -52,7 +67,7 @@ class Node(object):
         return obj
 
     def __str__(self):
-        return json.dumps(self.toJSON())
+        return json.dumps(self.to_json())
 
     def setPosition(self, start, end):
         if Node._pos is False:
@@ -88,11 +103,12 @@ class Entry(Node):
         super(Entry, self).__init__()
 
 class Message(Entry):
-    def __init__(self, id, value=None, attrs=None, tags=None, comment=None):
+    def __init__(
+            self, id, value=None, attributes=None, tags=None, comment=None):
         super(Message, self).__init__()
         self.id = id
         self.value = value
-        self.attributes = attrs
+        self.attributes = attributes
         self.tags = tags
         self.comment = comment
 

--- a/tests/syntax/test_ast_json.py
+++ b/tests/syntax/test_ast_json.py
@@ -1,0 +1,59 @@
+from __future__ import unicode_literals
+import unittest
+import textwrap
+import sys
+
+sys.path.append('.')
+
+from fluent.syntax.ast import from_json
+from fluent.syntax.parser import parse
+
+
+def dedent_ftl(text):
+    return textwrap.dedent(text.rstrip())
+
+
+class TestASTJSON(unittest.TestCase):
+    def test_simple_resource(self):
+        input = """\
+            foo = Foo
+        """
+
+        [ast1, _] = parse(dedent_ftl(input))
+        json1 = ast1.to_json()
+        ast2 = from_json(json1)
+        json2 = ast2.to_json()
+
+        self.assertEqual(json1, json2)
+
+    def test_complex_resource(self):
+        input = """\
+            // A Resource comment
+
+            // A comment about shared-photos
+            shared-photos =
+                { $user_name } { $photo_count ->
+                    [0] hasn't added any photos yet
+                    [one] added a new photo
+                   *[other] added { $photo_count } new photos
+                }.
+
+
+            // A Section comment
+            [[ Section ]]
+
+            // A comment about liked-comment
+            liked-comment =
+                { $user_name } liked your comment on { $user_gender ->
+                    [male] his
+                    [female] her
+                   *[other] their
+                } post.
+        """
+
+        [ast1, _] = parse(dedent_ftl(input))
+        json1 = ast1.to_json()
+        ast2 = from_json(json1)
+        json2 = ast2.to_json()
+
+        self.assertEqual(json1, json2)

--- a/tools/parse.py
+++ b/tools/parse.py
@@ -16,7 +16,7 @@ def read_file(path):
 
 def print_ast(fileType, data):
     [ast, errors] = fluent.syntax.parser.parse(data)
-    print(json.dumps(ast.toJSON(), indent=2, ensure_ascii=False))
+    print(json.dumps(ast.to_json(), indent=2, ensure_ascii=False))
 
     print('Errors:')
     for error in errors:


### PR DESCRIPTION
Working with ASTs serialized to JSON requires a way to build AST objects from
JSON objects.  fluent.syntax.ast.from_json takes a JSON representation of an
AST as input and returns AST nodes.

ast.Node.toJSON is also now called to_json to adhere to PEP8.