### PR TITLE
Rename transforms

### DIFF
--- a/fluent/migrate/__init__.py
+++ b/fluent/migrate/__init__.py
@@ -2,7 +2,9 @@
 
 from .context import MergeContext                      # noqa: F401
 from .transforms import (                              # noqa: F401
-    CONCAT, EXTERNAL, LITERAL, LITERAL_FROM, PLURALS, PLURALS_FROM, REPLACE,
-    REPLACE_FROM, SOURCE
+    Source, COPY, REPLACE_IN_TEXT, REPLACE, PLURALS, CONCAT
+)
+from .helpers import (                                 # noqa: F401
+    LITERAL, EXTERNAL_ARGUMENT, MESSAGE_REFERENCE
 )
 from .changesets import convert_blame_to_changesets    # noqa: F401

--- a/fluent/migrate/helpers.py
+++ b/fluent/migrate/helpers.py
@@ -1,0 +1,35 @@
+# coding=utf8
+"""Fluent AST helpers.
+
+The functions defined in this module offer a shorthand for defining common AST
+nodes.
+
+They take a string argument and immediately return a corresponding AST node.
+(As opposed to Transforms which are AST nodes on their own and only return the
+migrated AST nodes when they are evaluated by a MergeContext.) """
+
+from __future__ import unicode_literals
+
+import fluent.syntax.ast as FTL
+
+
+def LITERAL(value):
+    """Create a Pattern with a single TextElement."""
+    elements = [FTL.TextElement(value)]
+    return FTL.Pattern(elements)
+
+
+def EXTERNAL_ARGUMENT(name):
+    """Create an ExternalArgument expression."""
+
+    return FTL.ExternalArgument(
+        id=FTL.Identifier(name)
+    )
+
+
+def MESSAGE_REFERENCE(name):
+    """Create a MessageReference expression."""
+
+    return FTL.MessageReference(
+        id=FTL.Identifier(name)
+    )

--- a/tests/migrate/test_concat.py
+++ b/tests/migrate/test_concat.py
@@ -10,8 +10,11 @@ except ImportError:
     DTDParser = PropertiesParser = None
 
 from fluent.migrate.util import parse, ftl_message_to_json
+from fluent.migrate.helpers import (
+    LITERAL, EXTERNAL_ARGUMENT, MESSAGE_REFERENCE
+)
 from fluent.migrate.transforms import (
-    evaluate, CONCAT, LITERAL_FROM, EXTERNAL, REPLACE_FROM, LITERAL
+    evaluate, CONCAT, COPY, REPLACE
 )
 
 
@@ -37,7 +40,7 @@ class TestConcatCopy(MockContext):
         msg = FTL.Message(
             FTL.Identifier('hello'),
             value=CONCAT(
-                LITERAL_FROM(self.strings, 'hello'),
+                COPY(self.strings, 'hello'),
             )
         )
 
@@ -52,8 +55,8 @@ class TestConcatCopy(MockContext):
         msg = FTL.Message(
             FTL.Identifier('hello'),
             value=CONCAT(
-                LITERAL_FROM(self.strings, 'hello.start'),
-                LITERAL_FROM(self.strings, 'hello.end'),
+                COPY(self.strings, 'hello.start'),
+                COPY(self.strings, 'hello.end'),
             )
         )
 
@@ -87,8 +90,8 @@ class TestConcatCopy(MockContext):
         msg = FTL.Message(
             FTL.Identifier('hello'),
             value=CONCAT(
-                LITERAL_FROM(self.strings, 'whitespace.begin.start'),
-                LITERAL_FROM(self.strings, 'whitespace.begin.end'),
+                COPY(self.strings, 'whitespace.begin.start'),
+                COPY(self.strings, 'whitespace.begin.end'),
             )
         )
 
@@ -104,8 +107,8 @@ class TestConcatCopy(MockContext):
         msg = FTL.Message(
             FTL.Identifier('hello'),
             value=CONCAT(
-                LITERAL_FROM(self.strings, 'whitespace.end.start'),
-                LITERAL_FROM(self.strings, 'whitespace.end.end'),
+                COPY(self.strings, 'whitespace.end.start'),
+                COPY(self.strings, 'whitespace.end.end'),
             )
         )
 
@@ -130,11 +133,11 @@ class TestConcatLiteral(MockContext):
         msg = FTL.Message(
             FTL.Identifier('update-failed'),
             value=CONCAT(
-                LITERAL_FROM(self.strings, 'update.failed.start'),
+                COPY(self.strings, 'update.failed.start'),
                 LITERAL('<a>'),
-                LITERAL_FROM(self.strings, 'update.failed.linkText'),
+                COPY(self.strings, 'update.failed.linkText'),
                 LITERAL('</a>'),
-                LITERAL_FROM(self.strings, 'update.failed.end'),
+                COPY(self.strings, 'update.failed.end'),
             )
         )
 
@@ -159,9 +162,9 @@ class TestConcatInterpolate(MockContext):
         msg = FTL.Message(
             FTL.Identifier('channel-desc'),
             value=CONCAT(
-                LITERAL_FROM(self.strings, 'channel.description.start'),
-                EXTERNAL('channelname'),
-                LITERAL_FROM(self.strings, 'channel.description.end'),
+                COPY(self.strings, 'channel.description.start'),
+                EXTERNAL_ARGUMENT('channelname'),
+                COPY(self.strings, 'channel.description.end'),
             )
         )
 
@@ -188,39 +191,39 @@ class TestConcatReplace(MockContext):
         msg = FTL.Message(
             FTL.Identifier('community'),
             value=CONCAT(
-                REPLACE_FROM(
+                REPLACE(
                     self.strings,
                     'community.start',
                     {
-                        '&brandShortName;': FTL.ExternalArgument(
-                            id=FTL.Identifier('brand-short-name')
+                        '&brandShortName;': MESSAGE_REFERENCE(
+                            'brand-short-name'
                         )
                     }
                 ),
                 LITERAL('<a>'),
-                REPLACE_FROM(
+                REPLACE(
                     self.strings,
                     'community.mozillaLink',
                     {
-                        '&vendorShortName;': FTL.ExternalArgument(
-                            id=FTL.Identifier('vendor-short-name')
+                        '&vendorShortName;': MESSAGE_REFERENCE(
+                            'vendor-short-name'
                         )
                     }
                 ),
                 LITERAL('</a>'),
-                LITERAL_FROM(self.strings, 'community.middle'),
+                COPY(self.strings, 'community.middle'),
                 LITERAL('<a>'),
-                LITERAL_FROM(self.strings, 'community.creditsLink'),
+                COPY(self.strings, 'community.creditsLink'),
                 LITERAL('</a>'),
-                LITERAL_FROM(self.strings, 'community.end')
+                COPY(self.strings, 'community.end')
             )
         )
 
         self.assertEqual(
             evaluate(self, msg).to_json(),
             ftl_message_to_json(
-                'community = { $brand-short-name } is designed by '
-                '<a>{ $vendor-short-name }</a>, a <a>global community</a> '
+                'community = { brand-short-name } is designed by '
+                '<a>{ vendor-short-name }</a>, a <a>global community</a> '
                 'working together to…'
             )
         )

--- a/tests/migrate/test_context.py
+++ b/tests/migrate/test_context.py
@@ -9,7 +9,8 @@ import fluent.syntax.ast as FTL
 
 from fluent.migrate.util import ftl, ftl_resource_to_json, to_json
 from fluent.migrate.context import MergeContext
-from fluent.migrate.transforms import LITERAL, LITERAL_FROM
+from fluent.migrate.helpers import LITERAL
+from fluent.migrate.transforms import COPY
 
 
 def here(*parts):
@@ -59,7 +60,7 @@ class TestMergeContext(unittest.TestCase):
         self.ctx.add_transforms('aboutDownloads.ftl', [
             FTL.Message(
                 id=FTL.Identifier('title'),
-                value=LITERAL_FROM(
+                value=COPY(
                     'aboutDownloads.dtd',
                     'aboutDownloads.title'
                 )
@@ -85,14 +86,14 @@ class TestMergeContext(unittest.TestCase):
         self.ctx.add_transforms('aboutDownloads.ftl', [
             FTL.Message(
                 id=FTL.Identifier('title'),
-                value=LITERAL_FROM(
+                value=COPY(
                     'aboutDownloads.dtd',
                     'aboutDownloads.title'
                 )
             ),
             FTL.Message(
                 id=FTL.Identifier('header'),
-                value=LITERAL_FROM(
+                value=COPY(
                     'aboutDownloads.dtd',
                     'aboutDownloads.header'
                 )
@@ -124,14 +125,14 @@ class TestMergeContext(unittest.TestCase):
         self.ctx.add_transforms('aboutDownloads.ftl', [
             FTL.Message(
                 id=FTL.Identifier('title'),
-                value=LITERAL_FROM(
+                value=COPY(
                     'aboutDownloads.dtd',
                     'aboutDownloads.title'
                 )
             ),
             FTL.Message(
                 id=FTL.Identifier('header'),
-                value=LITERAL_FROM(
+                value=COPY(
                     'aboutDownloads.dtd',
                     'aboutDownloads.header'
                 )
@@ -177,14 +178,14 @@ class TestMergeContext(unittest.TestCase):
         self.ctx.add_transforms('aboutDownloads.ftl', [
             FTL.Message(
                 id=FTL.Identifier('title'),
-                value=LITERAL_FROM(
+                value=COPY(
                     'aboutDownloads.dtd',
                     'aboutDownloads.title'
                 )
             ),
             FTL.Message(
                 id=FTL.Identifier('header'),
-                value=LITERAL_FROM(
+                value=COPY(
                     'aboutDownloads.dtd',
                     'aboutDownloads.header'
                 )
@@ -270,14 +271,14 @@ class TestIncompleteLocalization(unittest.TestCase):
                 attributes=[
                     FTL.Attribute(
                         id=FTL.Identifier('placeholder'),
-                        value=LITERAL_FROM(
+                        value=COPY(
                             'browser.dtd',
                             'urlbar.placeholder2'
                         )
                     ),
                     FTL.Attribute(
                         id=FTL.Identifier('accesskey'),
-                        value=LITERAL_FROM(
+                        value=COPY(
                             'browser.dtd',
                             'urlbar.accesskey'
                         )

--- a/tests/migrate/test_context_real_examples.py
+++ b/tests/migrate/test_context_real_examples.py
@@ -8,9 +8,11 @@ import fluent.syntax.ast as FTL
 
 from fluent.migrate.util import ftl_resource_to_json, to_json
 from fluent.migrate.context import MergeContext
+from fluent.migrate.helpers import (
+    LITERAL, EXTERNAL_ARGUMENT, MESSAGE_REFERENCE
+)
 from fluent.migrate.transforms import (
-    CONCAT, EXTERNAL, LITERAL, LITERAL_FROM, PLURALS_FROM, REPLACE,
-    REPLACE_FROM
+    CONCAT, COPY, PLURALS, REPLACE_IN_TEXT, REPLACE
 )
 
 
@@ -37,21 +39,21 @@ class TestMergeAboutDownloads(unittest.TestCase):
         self.ctx.add_transforms('aboutDownloads.ftl', [
             FTL.Message(
                 id=FTL.Identifier('title'),
-                value=LITERAL_FROM(
+                value=COPY(
                     'aboutDownloads.dtd',
                     'aboutDownloads.title'
                 )
             ),
             FTL.Message(
                 id=FTL.Identifier('header'),
-                value=LITERAL_FROM(
+                value=COPY(
                     'aboutDownloads.dtd',
                     'aboutDownloads.header'
                 )
             ),
             FTL.Message(
                 id=FTL.Identifier('empty'),
-                value=LITERAL_FROM(
+                value=COPY(
                     'aboutDownloads.dtd',
                     'aboutDownloads.empty'
                 )
@@ -61,7 +63,7 @@ class TestMergeAboutDownloads(unittest.TestCase):
                 attributes=[
                     FTL.Attribute(
                         FTL.Identifier('label'),
-                        LITERAL_FROM(
+                        COPY(
                             'aboutDownloads.dtd',
                             'aboutDownloads.open'
                         )
@@ -73,7 +75,7 @@ class TestMergeAboutDownloads(unittest.TestCase):
                 attributes=[
                     FTL.Attribute(
                         FTL.Identifier('label'),
-                        LITERAL_FROM(
+                        COPY(
                             'aboutDownloads.dtd',
                             'aboutDownloads.retry'
                         )
@@ -85,7 +87,7 @@ class TestMergeAboutDownloads(unittest.TestCase):
                 attributes=[
                     FTL.Attribute(
                         FTL.Identifier('label'),
-                        LITERAL_FROM(
+                        COPY(
                             'aboutDownloads.dtd',
                             'aboutDownloads.remove'
                         )
@@ -97,7 +99,7 @@ class TestMergeAboutDownloads(unittest.TestCase):
                 attributes=[
                     FTL.Attribute(
                         FTL.Identifier('label'),
-                        LITERAL_FROM(
+                        COPY(
                             'aboutDownloads.dtd',
                             'aboutDownloads.pause'
                         )
@@ -109,7 +111,7 @@ class TestMergeAboutDownloads(unittest.TestCase):
                 attributes=[
                     FTL.Attribute(
                         FTL.Identifier('label'),
-                        LITERAL_FROM(
+                        COPY(
                             'aboutDownloads.dtd',
                             'aboutDownloads.resume'
                         )
@@ -121,7 +123,7 @@ class TestMergeAboutDownloads(unittest.TestCase):
                 attributes=[
                     FTL.Attribute(
                         FTL.Identifier('label'),
-                        LITERAL_FROM(
+                        COPY(
                             'aboutDownloads.dtd',
                             'aboutDownloads.cancel'
                         )
@@ -133,7 +135,7 @@ class TestMergeAboutDownloads(unittest.TestCase):
                 attributes=[
                     FTL.Attribute(
                         FTL.Identifier('label'),
-                        LITERAL_FROM(
+                        COPY(
                             'aboutDownloads.dtd',
                             'aboutDownloads.removeAll'
                         )
@@ -142,67 +144,63 @@ class TestMergeAboutDownloads(unittest.TestCase):
             ),
             FTL.Message(
                 id=FTL.Identifier('delete-all-title'),
-                value=LITERAL_FROM(
+                value=COPY(
                     'aboutDownloads.properties',
                     'downloadAction.deleteAll'
                 )
             ),
             FTL.Message(
                 id=FTL.Identifier('delete-all-message'),
-                value=PLURALS_FROM(
+                value=PLURALS(
                     'aboutDownloads.properties',
                     'downloadMessage.deleteAll',
-                    FTL.ExternalArgument(
-                        id=FTL.Identifier('num')
-                    ),
-                    lambda var: REPLACE(
-                        var,
+                    EXTERNAL_ARGUMENT('num'),
+                    lambda text: REPLACE_IN_TEXT(
+                        text,
                         {
-                            '#1': FTL.ExternalArgument(
-                                id=FTL.Identifier('num')
-                            )
+                            '#1': EXTERNAL_ARGUMENT('num')
                         }
                     )
                 )
             ),
             FTL.Message(
                 id=FTL.Identifier('download-state-downloading'),
-                value=LITERAL_FROM(
+                value=COPY(
                     'aboutDownloads.properties',
                     'downloadState.downloading'
                 )
             ),
             FTL.Message(
                 id=FTL.Identifier('download-state-canceled'),
-                value=LITERAL_FROM(
+                value=COPY(
                     'aboutDownloads.properties',
                     'downloadState.canceled'
                 )
             ),
             FTL.Message(
                 id=FTL.Identifier('download-state-failed'),
-                value=LITERAL_FROM(
+                value=COPY(
                     'aboutDownloads.properties',
                     'downloadState.failed'
                 )
             ),
             FTL.Message(
                 id=FTL.Identifier('download-state-paused'),
-                value=LITERAL_FROM(
+                value=COPY(
                     'aboutDownloads.properties',
                     'downloadState.paused'
                 )
             ),
             FTL.Message(
                 id=FTL.Identifier('download-state-starting'),
-                value=LITERAL_FROM(
+                value=COPY(
                     'aboutDownloads.properties',
                     'downloadState.starting'
                 )
             ),
             FTL.Message(
                 id=FTL.Identifier('download-size-unknown'),
-                value=LITERAL_FROM(
+                value=COPY(
                     'aboutDownloads.properties',
                     'downloadState.unknownSize'
                 )
@@ -302,51 +300,51 @@ class TestMergeAboutDialog(unittest.TestCase):
             FTL.Message(
                 id=FTL.Identifier('update-failed'),
                 value=CONCAT(
-                    LITERAL_FROM('aboutDialog.dtd', 'update.failed.start'),
+                    COPY('aboutDialog.dtd', 'update.failed.start'),
                     LITERAL('<a>'),
-                    LITERAL_FROM('aboutDialog.dtd', 'update.failed.linkText'),
+                    COPY('aboutDialog.dtd', 'update.failed.linkText'),
                     LITERAL('</a>'),
-                    LITERAL_FROM('aboutDialog.dtd', 'update.failed.end'),
+                    COPY('aboutDialog.dtd', 'update.failed.end'),
                 )
             ),
             FTL.Message(
                 id=FTL.Identifier('channel-desc'),
                 value=CONCAT(
-                    LITERAL_FROM(
+                    COPY(
                         'aboutDialog.dtd', 'channel.description.start'
                     ),
-                    EXTERNAL('channelname'),
-                    LITERAL_FROM('aboutDialog.dtd', 'channel.description.end'),
+                    EXTERNAL_ARGUMENT('channelname'),
+                    COPY('aboutDialog.dtd', 'channel.description.end'),
                 )
             ),
             FTL.Message(
                 id=FTL.Identifier('community'),
                 value=CONCAT(
-                    REPLACE_FROM(
+                    REPLACE(
                         'aboutDialog.dtd',
                         'community.start',
                         {
-                            '&brandShortName;': FTL.ExternalArgument(
-                                id=FTL.Identifier('brand-short-name')
+                            '&brandShortName;': MESSAGE_REFERENCE(
+                                'brand-short-name'
                             )
                         }
                     ),
                     LITERAL('<a>'),
-                    REPLACE_FROM(
+                    REPLACE(
                         'aboutDialog.dtd',
                         'community.mozillaLink',
                         {
-                            '&vendorBrandShortName;': FTL.ExternalArgument(
-                                id=FTL.Identifier('vendor-short-name')
+                            '&vendorBrandShortName;': MESSAGE_REFERENCE(
+                                'vendor-short-name'
                             )
                         }
                     ),
                     LITERAL('</a>'),
-                    LITERAL_FROM('aboutDialog.dtd', 'community.middle'),
+                    COPY('aboutDialog.dtd', 'community.middle'),
                     LITERAL('<a>'),
-                    LITERAL_FROM('aboutDialog.dtd', 'community.creditsLink'),
+                    COPY('aboutDialog.dtd', 'community.creditsLink'),
                     LITERAL('</a>'),
-                    LITERAL_FROM('aboutDialog.dtd', 'community.end')
+                    COPY('aboutDialog.dtd', 'community.end')
                 )
             ),
         ])

--- a/tests/migrate/test_literal.py
+++ b/tests/migrate/test_literal.py
@@ -10,7 +10,7 @@ except ImportError:
     PropertiesParser = DTDParser = None
 
 from fluent.migrate.util import parse, ftl_message_to_json
-from fluent.migrate.transforms import evaluate, LITERAL_FROM
+from fluent.migrate.transforms import evaluate, COPY
 
 
 class MockContext(unittest.TestCase):
@@ -33,7 +33,7 @@ class TestCopy(MockContext):
     def test_copy(self):
         msg = FTL.Message(
             FTL.Identifier('foo'),
-            value=LITERAL_FROM(self.strings, 'foo')
+            value=COPY(self.strings, 'foo')
         )
 
         self.assertEqual(
@@ -46,7 +46,7 @@ class TestCopy(MockContext):
     def test_copy_escape_unicode_middle(self):
         msg = FTL.Message(
             FTL.Identifier('foo-unicode-middle'),
-            value=LITERAL_FROM(self.strings, 'foo.unicode.middle')
+            value=COPY(self.strings, 'foo.unicode.middle')
         )
 
         self.assertEqual(
@@ -60,7 +60,7 @@ class TestCopy(MockContext):
     def test_copy_escape_unicode_begin(self):
         msg = FTL.Message(
             FTL.Identifier('foo-unicode-begin'),
-            value=LITERAL_FROM(self.strings, 'foo.unicode.begin')
+            value=COPY(self.strings, 'foo.unicode.begin')
         )
 
         self.assertEqual(
@@ -74,7 +74,7 @@ class TestCopy(MockContext):
     def test_copy_escape_unicode_end(self):
         msg = FTL.Message(
             FTL.Identifier('foo-unicode-end'),
-            value=LITERAL_FROM(self.strings, 'foo.unicode.end')
+            value=COPY(self.strings, 'foo.unicode.end')
         )
 
         self.assertEqual(
@@ -87,7 +87,7 @@ class TestCopy(MockContext):
     def test_copy_html_entity(self):
         msg = FTL.Message(
             FTL.Identifier('foo-html-entity'),
-            value=LITERAL_FROM(self.strings, 'foo.html.entity')
+            value=COPY(self.strings, 'foo.html.entity')
         )
 
         self.assertEqual(
@@ -112,11 +112,11 @@ class TestCopyTraits(MockContext):
             attributes=[
                 FTL.Attribute(
                     FTL.Identifier('label'),
-                    LITERAL_FROM(self.strings, 'checkForUpdatesButton.label')
+                    COPY(self.strings, 'checkForUpdatesButton.label')
                 ),
                 FTL.Attribute(
                     FTL.Identifier('accesskey'),
-                    LITERAL_FROM(
+                    COPY(
                         self.strings, 'checkForUpdatesButton.accesskey'
                     )
                 ),

--- a/tests/migrate/test_merge.py
+++ b/tests/migrate/test_merge.py
@@ -12,7 +12,8 @@ except ImportError:
 
 from fluent.migrate.util import parse, ftl, ftl_resource_to_json
 from fluent.migrate.merge import merge_resource
-from fluent.migrate.transforms import LITERAL, LITERAL_FROM
+from fluent.migrate.helpers import LITERAL
+from fluent.migrate.transforms import COPY
 
 
 class MockContext(unittest.TestCase):
@@ -59,7 +60,7 @@ class TestMergeMessages(MockContext):
         self.transforms = [
             FTL.Message(
                 FTL.Identifier('title'),
-                value=LITERAL_FROM(None, 'aboutDownloads.title')
+                value=COPY(None, 'aboutDownloads.title')
             ),
             FTL.Message(
                 FTL.Identifier('about'),
@@ -70,13 +71,13 @@ class TestMergeMessages(MockContext):
                 attributes=[
                     FTL.Attribute(
                         FTL.Identifier('label'),
-                        LITERAL_FROM(None, 'aboutDownloads.open')
+                        COPY(None, 'aboutDownloads.open')
                     ),
                 ]
             ),
             FTL.Message(
                 FTL.Identifier('download-state-downloading'),
-                value=LITERAL_FROM(None, 'downloadState.downloading')
+                value=COPY(None, 'downloadState.downloading')
             )
         ]
 
@@ -167,20 +168,20 @@ class TestMergeAllEntries(MockContext):
         self.transforms = [
             FTL.Message(
                 FTL.Identifier('title'),
-                value=LITERAL_FROM(None, 'aboutDownloads.title')
+                value=COPY(None, 'aboutDownloads.title')
             ),
             FTL.Message(
                 FTL.Identifier('open-menuitem'),
                 attributes=[
                     FTL.Attribute(
                         FTL.Identifier('label'),
-                        LITERAL_FROM(None, 'aboutDownloads.open')
+                        COPY(None, 'aboutDownloads.open')
                     ),
                 ]
             ),
             FTL.Message(
                 FTL.Identifier('download-state-downloading'),
-                value=LITERAL_FROM(None, 'downloadState.downloading')
+                value=COPY(None, 'downloadState.downloading')
             )
         ]
 
@@ -280,11 +281,11 @@ class TestMergeSubset(MockContext):
         self.transforms = [
             FTL.Message(
                 FTL.Identifier('title'),
-                value=LITERAL_FROM(None, 'aboutDownloads.title')
+                value=COPY(None, 'aboutDownloads.title')
             ),
             FTL.Message(
                 FTL.Identifier('download-state-downloading'),
-                value=LITERAL_FROM(None, 'downloadState.downloading')
+                value=COPY(None, 'downloadState.downloading')
             )
         ]
 

--- a/tests/migrate/test_replace.py
+++ b/tests/migrate/test_replace.py
@@ -10,7 +10,8 @@ except ImportError:
     PropertiesParser = None
 
 from fluent.migrate.util import parse, ftl_message_to_json
-from fluent.migrate.transforms import evaluate, REPLACE_FROM
+from fluent.migrate.helpers import EXTERNAL_ARGUMENT
+from fluent.migrate.transforms import evaluate, REPLACE
 
 
 class MockContext(unittest.TestCase):
@@ -31,13 +32,11 @@ class TestReplace(MockContext):
     def test_replace_one(self):
         msg = FTL.Message(
             FTL.Identifier(u'hello'),
-            value=REPLACE_FROM(
+            value=REPLACE(
                 self.strings,
                 'hello',
                 {
-                    '#1': FTL.ExternalArgument(
-                        id=FTL.Identifier('username')
-                    )
+                    '#1': EXTERNAL_ARGUMENT('username')
                 }
             )
         )
@@ -52,16 +51,12 @@ class TestReplace(MockContext):
     def test_replace_two(self):
         msg = FTL.Message(
             FTL.Identifier(u'welcome'),
-            value=REPLACE_FROM(
+            value=REPLACE(
                 self.strings,
                 'welcome',
                 {
-                    '#1': FTL.ExternalArgument(
-                        id=FTL.Identifier('username')
-                    ),
-                    '#2': FTL.ExternalArgument(
-                        id=FTL.Identifier('appname')
-                    )
+                    '#1': EXTERNAL_ARGUMENT('username'),
+                    '#2': EXTERNAL_ARGUMENT('appname')
                 }
             )
         )
@@ -76,19 +71,13 @@ class TestReplace(MockContext):
     def test_replace_too_many(self):
         msg = FTL.Message(
             FTL.Identifier(u'welcome'),
-            value=REPLACE_FROM(
+            value=REPLACE(
                 self.strings,
                 'welcome',
                 {
-                    '#1': FTL.ExternalArgument(
-                        id=FTL.Identifier('username')
-                    ),
-                    '#2': FTL.ExternalArgument(
-                        id=FTL.Identifier('appname')
-                    ),
-                    '#3': FTL.ExternalArgument(
-                        id=FTL.Identifier('extraname')
-                    )
+                    '#1': EXTERNAL_ARGUMENT('username'),
+                    '#2': EXTERNAL_ARGUMENT('appname'),
+                    '#3': EXTERNAL_ARGUMENT('extraname')
                 }
             )
         )
@@ -103,13 +92,11 @@ class TestReplace(MockContext):
     def test_replace_too_few(self):
         msg = FTL.Message(
             FTL.Identifier(u'welcome'),
-            value=REPLACE_FROM(
+            value=REPLACE(
                 self.strings,
                 'welcome',
                 {
-                    '#1': FTL.ExternalArgument(
-                        id=FTL.Identifier('username')
-                    )
+                    '#1': EXTERNAL_ARGUMENT('username')
                 }
             )
         )
@@ -124,13 +111,11 @@ class TestReplace(MockContext):
     def test_replace_first(self):
         msg = FTL.Message(
             FTL.Identifier(u'first'),
-            value=REPLACE_FROM(
+            value=REPLACE(
                 self.strings,
                 'first',
                 {
-                    '#1': FTL.ExternalArgument(
-                        id=FTL.Identifier('foo')
-                    )
+                    '#1': EXTERNAL_ARGUMENT('foo')
                 }
             )
         )
@@ -145,13 +130,11 @@ class TestReplace(MockContext):
     def test_replace_last(self):
         msg = FTL.Message(
             FTL.Identifier(u'last'),
-            value=REPLACE_FROM(
+            value=REPLACE(
                 self.strings,
                 'last',
                 {
-                    '#1': FTL.ExternalArgument(
-                        id=FTL.Identifier('bar')
-                    )
+                    '#1': EXTERNAL_ARGUMENT('bar')
                 }
             )
         )

--- a/tests/migrate/test_util.py
+++ b/tests/migrate/test_util.py
@@ -5,11 +5,11 @@ import unittest
 
 import fluent.syntax.ast as FTL
 from fluent.util import fold
-from fluent.migrate.transforms import CONCAT, LITERAL_FROM, SOURCE
+from fluent.migrate.transforms import CONCAT, COPY, Source
 
 
 def get_source(acc, cur):
-    if isinstance(cur, SOURCE):
+    if isinstance(cur, Source):
         return acc + ((cur.path, cur.key),)
     return acc
 
@@ -19,8 +19,8 @@ class TestTraverse(unittest.TestCase):
         node = FTL.Message(
             FTL.Identifier('hello'),
             value=CONCAT(
-                LITERAL_FROM('path1', 'key1'),
-                LITERAL_FROM('path2', 'key2')
+                COPY('path1', 'key1'),
+                COPY('path2', 'key2')
             )
         )
 
@@ -40,7 +40,7 @@ class TestReduce(unittest.TestCase):
     def test_copy_value(self):
         node = FTL.Message(
             id=FTL.Identifier('key'),
-            value=LITERAL_FROM('path', 'key')
+            value=COPY('path', 'key')
         )
 
         self.assertEqual(
@@ -54,11 +54,11 @@ class TestReduce(unittest.TestCase):
             attributes=[
                 FTL.Attribute(
                     FTL.Identifier('trait1'),
-                    value=LITERAL_FROM('path1', 'key1')
+                    value=COPY('path1', 'key1')
                 ),
                 FTL.Attribute(
                     FTL.Identifier('trait2'),
-                    value=LITERAL_FROM('path2', 'key2')
+                    value=COPY('path2', 'key2')
                 )
             ]
         )
@@ -72,8 +72,8 @@ class TestReduce(unittest.TestCase):
         node = FTL.Message(
             FTL.Identifier('hello'),
             value=CONCAT(
-                LITERAL_FROM('path1', 'key1'),
-                LITERAL_FROM('path2', 'key2')
+                COPY('path1', 'key1'),
+                COPY('path2', 'key2')
             )
         )
 

--- a/tools/migrate/about_dialog.py
+++ b/tools/migrate/about_dialog.py
@@ -1,7 +1,10 @@
 # coding=utf8
 
 import fluent.syntax.ast as FTL
-from fluent.migrate import CONCAT, EXTERNAL, LITERAL, LITERAL_FROM, REPLACE_FROM
+from fluent.migrate import (
+    CONCAT, LITERAL, EXTERNAL_ARGUMENT, MESSAGE_REFERENCE, COPY,
+    REPLACE
+)
 
 
 def migrate(ctx):
@@ -11,73 +14,73 @@ def migrate(ctx):
     ctx.add_localization('browser/chrome/browser/aboutDialog.dtd')
 
     ctx.add_transforms('browser/aboutDialog.ftl', [
-        FTL.Entity(
+        FTL.Message(
             id=FTL.Identifier('update-failed'),
             value=CONCAT(
-                LITERAL_FROM(
+                COPY(
                     'browser/chrome/browser/aboutDialog.dtd',
                     'update.failed.start'
                 ),
                 LITERAL('<a>'),
-                LITERAL_FROM(
+                COPY(
                     'browser/chrome/browser/aboutDialog.dtd',
                     'update.failed.linkText'
                 ),
                 LITERAL('</a>'),
-                LITERAL_FROM(
+                COPY(
                     'browser/chrome/browser/aboutDialog.dtd',
                     'update.failed.end'
                 )
             )
         ),
-        FTL.Entity(
+        FTL.Message(
             id=FTL.Identifier('channel-desc'),
             value=CONCAT(
-                LITERAL_FROM(
+                COPY(
                     'browser/chrome/browser/aboutDialog.dtd',
                     'channel.description.start'
                 ),
-                EXTERNAL('channelname'),
-                LITERAL_FROM(
+                EXTERNAL_ARGUMENT('channelname'),
+                COPY(
                     'browser/chrome/browser/aboutDialog.dtd',
                     'channel.description.end'
                 )
             )
         ),
-        FTL.Entity(
+        FTL.Message(
             id=FTL.Identifier('community'),
             value=CONCAT(
-                REPLACE_FROM(
+                REPLACE(
                     'browser/chrome/browser/aboutDialog.dtd',
                     'community.start2',
                     {
-                        '&brandShortName;': FTL.ExternalArgument(
-                            id=FTL.Identifier('brand-short-name')
+                        '&brandShortName;': MESSAGE_REFERENCE(
+                            'brand-short-name'
                         )
                     }
                 ),
                 LITERAL('<a>'),
-                REPLACE_FROM(
+                REPLACE(
                     'browser/chrome/browser/aboutDialog.dtd',
                     'community.mozillaLink',
                     {
-                        '&vendorShortName;': FTL.ExternalArgument(
-                            id=FTL.Identifier('vendor-short-name')
+                        '&vendorShortName;': MESSAGE_REFERENCE(
+                            'vendor-short-name'
                         )
                     }
                 ),
                 LITERAL('</a>'),
-                LITERAL_FROM(
+                COPY(
                     'browser/chrome/browser/aboutDialog.dtd',
                     'community.middle2'
                 ),
                 LITERAL('<a>'),
-                LITERAL_FROM(
+                COPY(
                     'browser/chrome/browser/aboutDialog.dtd',
                     'community.creditsLink'
                 ),
                 LITERAL('</a>'),
-                LITERAL_FROM(
+                COPY(
                     'browser/chrome/browser/aboutDialog.dtd',
                     'community.end3'
                 )

--- a/tools/migrate/about_downloads.py
+++ b/tools/migrate/about_downloads.py
@@ -1,7 +1,7 @@
 # coding=utf8
 
 import fluent.syntax.ast as FTL
-from fluent.migrate import LITERAL_FROM, PLURALS_FROM, REPLACE
+from fluent.migrate import EXTERNAL_ARGUMENT, COPY, PLURALS, REPLACE
 
 
 def migrate(ctx):
@@ -15,174 +15,170 @@ def migrate(ctx):
     ctx.add_localization('mobile/android/chrome/aboutDownloads.properties')
 
     ctx.add_transforms('mobile/aboutDownloads.ftl', [
-        FTL.Entity(
+        FTL.Message(
             id=FTL.Identifier('title'),
-            value=LITERAL_FROM(
+            value=COPY(
                 'mobile/android/chrome/aboutDownloads.dtd',
                 'aboutDownloads.title'
             )
         ),
-        FTL.Entity(
+        FTL.Message(
             id=FTL.Identifier('header'),
-            value=LITERAL_FROM(
+            value=COPY(
                 'mobile/android/chrome/aboutDownloads.dtd',
                 'aboutDownloads.header'
             )
         ),
-        FTL.Entity(
+        FTL.Message(
             id=FTL.Identifier('empty'),
-            value=LITERAL_FROM(
+            value=COPY(
                 'mobile/android/chrome/aboutDownloads.dtd',
                 'aboutDownloads.empty'
             )
         ),
-        FTL.Entity(
+        FTL.Message(
             id=FTL.Identifier('open-menuitem'),
             attributes=[
                 FTL.Attribute(
                     FTL.Identifier('label'),
-                    LITERAL_FROM(
+                    COPY(
                         'mobile/android/chrome/aboutDownloads.dtd',
                         'aboutDownloads.open'
                     )
                 )
             ]
         ),
-        FTL.Entity(
+        FTL.Message(
             id=FTL.Identifier('retry-menuitem'),
             attributes=[
                 FTL.Attribute(
                     FTL.Identifier('label'),
-                    LITERAL_FROM(
+                    COPY(
                         'mobile/android/chrome/aboutDownloads.dtd',
                         'aboutDownloads.retry'
                     )
                 )
             ]
         ),
-        FTL.Entity(
+        FTL.Message(
             id=FTL.Identifier('remove-menuitem'),
             attributes=[
                 FTL.Attribute(
                     FTL.Identifier('label'),
-                    LITERAL_FROM(
+                    COPY(
                         'mobile/android/chrome/aboutDownloads.dtd',
                         'aboutDownloads.remove'
                     )
                 )
             ]
         ),
-        FTL.Entity(
+        FTL.Message(
             id=FTL.Identifier('pause-menuitem'),
             attributes=[
                 FTL.Attribute(
                     FTL.Identifier('label'),
-                    LITERAL_FROM(
+                    COPY(
                         'mobile/android/chrome/aboutDownloads.dtd',
                         'aboutDownloads.pause'
                     )
                 )
             ]
         ),
-        FTL.Entity(
+        FTL.Message(
             id=FTL.Identifier('resume-menuitem'),
             attributes=[
                 FTL.Attribute(
                     FTL.Identifier('label'),
-                    LITERAL_FROM(
+                    COPY(
                         'mobile/android/chrome/aboutDownloads.dtd',
                         'aboutDownloads.resume'
                     )
                 )
             ]
         ),
-        FTL.Entity(
+        FTL.Message(
             id=FTL.Identifier('cancel-menuitem'),
             attributes=[
                 FTL.Attribute(
                     FTL.Identifier('label'),
-                    LITERAL_FROM(
+                    COPY(
                         'mobile/android/chrome/aboutDownloads.dtd',
                         'aboutDownloads.cancel'
                     )
                 )
             ]
         ),
-        FTL.Entity(
+        FTL.Message(
             id=FTL.Identifier('remove-all-menuitem'),
             attributes=[
                 FTL.Attribute(
                     FTL.Identifier('label'),
-                    LITERAL_FROM(
+                    COPY(
                         'mobile/android/chrome/aboutDownloads.dtd',
                         'aboutDownloads.removeAll'
                     )
                 )
             ]
         ),
-        FTL.Entity(
+        FTL.Message(
             id=FTL.Identifier('delete-all-title'),
-            value=LITERAL_FROM(
+            value=COPY(
                 'mobile/android/chrome/aboutDownloads.properties',
                 'downloadAction.deleteAll'
             )
         ),
-        FTL.Entity(
+        FTL.Message(
             id=FTL.Identifier('delete-all-message'),
-            value=PLURALS_FROM(
+            value=PLURALS(
                 'mobile/android/chrome/aboutDownloads.properties',
                 'downloadMessage.deleteAll',
-                FTL.ExternalArgument(
-                    id=FTL.Identifier('num')
-                ),
-                lambda var: REPLACE(
-                    var,
+                EXTERNAL_ARGUMENT('num'),
+                lambda text: REPLACE_IN_TEXT(
+                    text,
                     {
-                        '#1': FTL.ExternalArgument(
-                            id=FTL.Identifier('num')
-                        )
+                        '#1': EXTERNAL_ARGUMENT('num')
                     }
                 )
             )
         ),
-        FTL.Entity(
+        FTL.Message(
             id=FTL.Identifier('download-state-downloading'),
-            value=LITERAL_FROM(
+            value=COPY(
                 'mobile/android/chrome/aboutDownloads.properties',
                 'downloadState.downloading'
             )
         ),
-        FTL.Entity(
+        FTL.Message(
             id=FTL.Identifier('download-state-canceled'),
-            value=LITERAL_FROM(
+            value=COPY(
                 'mobile/android/chrome/aboutDownloads.properties',
                 'downloadState.canceled'
             )
         ),
-        FTL.Entity(
+        FTL.Message(
             id=FTL.Identifier('download-state-failed'),
-            value=LITERAL_FROM(
+            value=COPY(
                 'mobile/android/chrome/aboutDownloads.properties',
                 'downloadState.failed'
             )
         ),
-        FTL.Entity(
+        FTL.Message(
             id=FTL.Identifier('download-state-paused'),
-            value=LITERAL_FROM(
+            value=COPY(
                 'mobile/android/chrome/aboutDownloads.properties',
                 'downloadState.paused'
             )
         ),
-        FTL.Entity(
+        FTL.Message(
             id=FTL.Identifier('download-state-starting'),
-            value=LITERAL_FROM(
+            value=COPY(
                 'mobile/android/chrome/aboutDownloads.properties',
                 'downloadState.starting'
             )
         ),
-        FTL.Entity(
+        FTL.Message(
             id=FTL.Identifier('download-size-unknown'),
-            value=LITERAL_FROM(
+            value=COPY(
                 'mobile/android/chrome/aboutDownloads.properties',
                 'downloadState.unknownSize'
             )


### PR DESCRIPTION
Commonly used Transforms which take source information and return Patterns have been renamed as follows:

    LITERAL_FROM → COPY
    REPLACE_FROM → REPLACE
    PLURALS_FROM → PLURALS

Existing primitive Transforms which take text as input are still useful for defining transform functions for variants of the PLURAL transform. They have been changed as follows:

    LITERAL → COPY_TEXT
    REPLACE → REPLACE_TEXT
    PLURALS → (removed)

In addition, the following three helper Transforms have been added:

    TEXT_ELEMENT, EXTERNAL_ARGUMENT and MESSAGE_REFERENCE

They represent common operations in migrations.  In contrast to the ones above, these three do not evauate to Patterns.  Instead, they evaluate to `TextElement` or `Expression` nodes. The CONCAT transform can now accept these as well.