### PR TITLE
Add Spans to all Nodes

### DIFF
--- a/fluent/migrate/context.py
+++ b/fluent/migrate/context.py
@@ -46,9 +46,7 @@ class MergeContext(object):
     """
 
     def __init__(self, lang, reference_dir, localization_dir):
-        self.fluent_parser = FluentParser(
-            with_spans=False, with_annotations=False
-        )
+        self.fluent_parser = FluentParser(with_spans=False)
         self.fluent_serializer = FluentSerializer()
 
         # An iterable of plural category names relevant to the context's

--- a/fluent/migrate/transforms.py
+++ b/fluent/migrate/transforms.py
@@ -79,7 +79,7 @@ def evaluate(ctx, node):
     return node.traverse(eval_node)
 
 
-class Transform(FTL.Node):
+class Transform(FTL.BaseNode):
     def __call__(self, ctx):
         raise NotImplementedError
 
@@ -282,7 +282,7 @@ class CONCAT(Transform):
 
     def traverse(self, fun):
         def visit(value):
-            if isinstance(value, FTL.Node):
+            if isinstance(value, FTL.BaseNode):
                 return value.traverse(fun)
             if isinstance(value, list):
                 return fun(map(visit, value))
@@ -299,7 +299,7 @@ class CONCAT(Transform):
 
     def to_json(self):
         def to_json(value):
-            if isinstance(value, FTL.Node):
+            if isinstance(value, FTL.BaseNode):
                 return value.to_json()
             else:
                 return value

--- a/fluent/migrate/util.py
+++ b/fluent/migrate/util.py
@@ -6,10 +6,7 @@ from fluent.syntax.parser import FluentParser
 from fluent.util import ftl
 
 
-fluent_parser = FluentParser(
-    with_spans=False,
-    with_annotations=False
-)
+fluent_parser = FluentParser(with_spans=False)
 
 
 def parse(Parser, string):

--- a/fluent/syntax/parser.py
+++ b/fluent/syntax/parser.py
@@ -18,7 +18,7 @@ class FluentParser(object):
         entries = []
 
         while ps.current():
-            entry = get_entry_or_junk(self, ps)
+            entry = self.get_entry_or_junk(ps)
 
             if isinstance(entry, ast.Comment) and len(entries) == 0:
                 comment = entry
@@ -32,467 +32,465 @@ class FluentParser(object):
     def parse_entry(self, source):
         ps = FTLParserStream(source)
         ps.skip_ws_lines()
-        return get_entry_or_junk(self, ps)
+        return self.get_entry_or_junk(ps)
 
+    def get_entry_or_junk(self, ps):
+        entry_start_pos = ps.get_index()
 
-def get_entry_or_junk(self, ps):
-    entry_start_pos = ps.get_index()
+        try:
+            entry = self.get_entry(ps)
+            if self.with_spans:
+                entry.add_span(entry_start_pos, ps.get_index())
+            return entry
+        except ParseError as err:
+            error_index = ps.get_index()
+            ps.skip_to_next_entry_start()
+            next_entry_start = ps.get_index()
 
-    try:
-        entry = get_entry(ps)
-        if self.with_spans:
-            entry.add_span(entry_start_pos, ps.get_index())
-        return entry
-    except ParseError as err:
-        error_index = ps.get_index()
-        ps.skip_to_next_entry_start()
-        next_entry_start = ps.get_index()
+            # Create a Junk instance
+            slice = ps.get_slice(entry_start_pos, next_entry_start)
+            junk = ast.Junk(slice)
+            if self.with_spans:
+                junk.add_span(entry_start_pos, next_entry_start)
+            if self.with_annotations:
+                annot = ast.Annotation(err.code, err.args, err.message)
+                annot.add_span(error_index, error_index)
+                junk.add_annotation(annot)
+            return junk
 
-        # Create a Junk instance
-        slice = ps.get_slice(entry_start_pos, next_entry_start)
-        junk = ast.Junk(slice)
-        if self.with_spans:
-            junk.add_span(entry_start_pos, next_entry_start)
-        if self.with_annotations:
-            annot = ast.Annotation(err.code, err.args, err.message)
-            annot.add_span(error_index, error_index)
-            junk.add_annotation(annot)
-        return junk
-
-
-def get_entry(ps):
-    comment = None
-
-    if ps.current_is('/'):
-        comment = get_comment(ps)
-
-    if ps.current_is('['):
-        return get_section(ps, comment)
-
-    if ps.is_id_start():
-        return get_message(ps, comment)
-
-    if comment:
-        return comment
-
-    raise ParseError('E0002')
-
-def get_comment(ps):
-    ps.expect_char('/')
-    ps.expect_char('/')
-    ps.take_char_if(' ')
-
-    content = ''
-
-    def until_eol(x):
-        return x != '\n'
-
-    while True:
-        ch = ps.take_char(until_eol)
-        while ch:
-            content += ch
-            ch = ps.take_char(until_eol)
-
-        ps.next()
+    def get_entry(self, ps):
+        comment = None
 
         if ps.current_is('/'):
-            content += '\n'
+            comment = self.get_comment(ps)
+
+        if ps.current_is('['):
+            return self.get_section(ps, comment)
+
+        if ps.is_id_start():
+            return self.get_message(ps, comment)
+
+        if comment:
+            return comment
+
+        raise ParseError('E0002')
+
+    def get_comment(self, ps):
+        ps.expect_char('/')
+        ps.expect_char('/')
+        ps.take_char_if(' ')
+
+        content = ''
+
+        def until_eol(x):
+            return x != '\n'
+
+        while True:
+            ch = ps.take_char(until_eol)
+            while ch:
+                content += ch
+                ch = ps.take_char(until_eol)
+
             ps.next()
-            ps.expect_char('/')
-            ps.take_char_if(' ')
-        else:
-            break
-    return ast.Comment(content)
 
-def get_section(ps, comment):
-    ps.expect_char('[')
-    ps.expect_char('[')
+            if ps.current_is('/'):
+                content += '\n'
+                ps.next()
+                ps.expect_char('/')
+                ps.take_char_if(' ')
+            else:
+                break
+        return ast.Comment(content)
 
-    ps.skip_line_ws()
-
-    symb = get_symbol(ps)
-
-    ps.skip_line_ws()
-
-    ps.expect_char(']')
-    ps.expect_char(']')
-
-    ps.skip_line_ws()
-
-    ps.expect_char('\n')
-
-    return ast.Section(symb, comment)
-
-def get_message(ps, comment):
-    id = get_identifier(ps)
-
-    ps.skip_line_ws()
-
-    pattern = None
-    attrs = None
-    tags = None
-
-    if ps.current_is('='):
-        ps.next()
-        ps.skip_line_ws()
-
-        pattern = get_pattern(ps)
-
-    if ps.is_peek_next_line_attribute_start():
-        attrs = get_attributes(ps)
-
-    if ps.is_peek_next_line_tag_start():
-        if attrs is not None:
-            raise ParseError('E0012')
-        tags = get_tags(ps)
-
-    if pattern is None and attrs is None and tags is None:
-        raise ParseError('E0005', id.name)
-
-    return ast.Message(id, pattern, attrs, tags, comment)
-
-def get_attributes(ps):
-    attrs = []
-
-    while True:
-        ps.expect_char('\n')
-        ps.skip_line_ws()
-
-        ps.expect_char('.')
-
-        key = get_identifier(ps)
-
-        ps.skip_line_ws()
-        ps.expect_char('=')
-        ps.skip_line_ws()
-
-        value = get_pattern(ps)
-
-        if value is None:
-            raise ParseError('E0006', 'value')
-
-        attrs.append(ast.Attribute(key, value))
-
-        if not ps.is_peek_next_line_attribute_start():
-            break
-    return attrs
-
-def get_tags(ps):
-    tags = []
-
-    while True:
-        ps.expect_char('\n')
-        ps.skip_line_ws()
-
-        ps.expect_char('#')
-
-        symb = get_symbol(ps)
-
-        tags.append(ast.Tag(symb))
-
-        if not ps.is_peek_next_line_tag_start():
-            break
-    return tags
-
-def get_identifier(ps):
-    name = ''
-
-    name += ps.take_id_start()
-
-    ch = ps.take_id_char()
-    while ch:
-        name += ch
-        ch = ps.take_id_char()
-
-    return ast.Identifier(name)
-
-def get_variant_key(ps):
-    ch = ps.current()
-
-    if ch is None:
-        raise ParseError('E0013')
-
-    if ps.is_number_start():
-        return get_number(ps)
-
-    return get_symbol(ps)
-
-def get_variants(ps):
-    variants = []
-    has_default = False
-
-    while True:
-        default_index = False
-
-        ps.expect_char('\n')
-        ps.skip_line_ws()
-
-        if ps.current_is('*'):
-            if has_default:
-                raise ParseError('E0015')
-            ps.next()
-            default_index = True
-            has_default = True
-
+    def get_section(self, ps, comment):
+        ps.expect_char('[')
         ps.expect_char('[')
 
-        key = get_variant_key(ps)
+        ps.skip_line_ws()
 
+        symb = self.get_symbol(ps)
+
+        ps.skip_line_ws()
+
+        ps.expect_char(']')
         ps.expect_char(']')
 
         ps.skip_line_ws()
 
-        value = get_pattern(ps)
-
-        if value is None:
-            raise ParseError('E0006', 'value')
-
-        variants.append(ast.Variant(key, value, default_index))
-
-        if not ps.is_peek_next_line_variant_start():
-            break
-
-    if not has_default:
-        raise ParseError('E0010')
-
-    return variants
-
-def get_symbol(ps):
-    name = ''
-
-    name += ps.take_id_start()
-
-    while True:
-        ch = ps.take_symb_char()
-        if ch:
-            name += ch
-        else:
-            break
-
-    return ast.Symbol(name.rstrip())
-
-def get_digits(ps):
-    num = ''
-
-    ch = ps.take_digit()
-    while ch:
-        num += ch
-        ch = ps.take_digit()
-
-    if len(num) == 0:
-        raise ParseError('E0004', '0-9')
-
-    return num
-
-def get_number(ps):
-    num = ''
-
-    if ps.current_is('-'):
-        num += '-'
-        ps.next()
-
-    num += get_digits(ps)
-
-    if ps.current_is('.'):
-        num += '.'
-        ps.next()
-        num += get_digits(ps)
-
-    return ast.NumberExpression(num)
-
-def get_pattern(ps):
-    buffer = ''
-    elements = []
-    first_line = True
-
-    while ps.current():
-        ch = ps.current()
-        if ch == '\n':
-            if first_line and len(buffer) != 0:
-                break
-
-            if not ps.is_peek_next_line_pattern():
-                break
-
-            ps.next()
-            ps.skip_line_ws()
-
-            if not first_line:
-                buffer += ch
-
-            first_line = False
-            continue
-        elif ch == '\\':
-            ch2 = ps.peek()
-
-            if ch2 == '{' or ch2 == '"':
-                buffer += ch2
-            else:
-                buffer += ch + ch2
-            ps.next()
-        elif ch == '{':
-            ps.next()
-
-            ps.skip_line_ws()
-
-            if len(buffer) != 0:
-                elements.append(ast.TextElement(buffer))
-
-            buffer = ''
-
-            elements.append(get_expression(ps))
-
-            ps.expect_char('}')
-
-            continue
-        else:
-            buffer += ps.ch
-        ps.next()
-
-    if len(buffer) != 0:
-        elements.append(ast.TextElement(buffer))
-
-    return ast.Pattern(elements)
-
-def get_expression(ps):
-    if ps.is_peek_next_line_variant_start():
-        variants = get_variants(ps)
-
         ps.expect_char('\n')
-        ps.expect_char(' ')
+
+        return ast.Section(symb, comment)
+
+    def get_message(self, ps, comment):
+        id = self.get_identifier(ps)
+
         ps.skip_line_ws()
 
-        return ast.SelectExpression(None, variants)
+        pattern = None
+        attrs = None
+        tags = None
 
-    selector = get_selector_expression(ps)
-
-    ps.skip_line_ws()
-
-    if ps.current_is('-'):
-        ps.peek()
-        if not ps.current_peek_is('>'):
-            ps.reset_peek()
-        else:
+        if ps.current_is('='):
             ps.next()
-            ps.next()
+            ps.skip_line_ws()
+
+            pattern = self.get_pattern(ps)
+
+        if ps.is_peek_next_line_attribute_start():
+            attrs = self.get_attributes(ps)
+
+        if ps.is_peek_next_line_tag_start():
+            if attrs is not None:
+                raise ParseError('E0012')
+            tags = self.get_tags(ps)
+
+        if pattern is None and attrs is None and tags is None:
+            raise ParseError('E0005', id.name)
+
+        return ast.Message(id, pattern, attrs, tags, comment)
+
+    def get_attributes(self, ps):
+        attrs = []
+
+        while True:
+            ps.expect_char('\n')
+            ps.skip_line_ws()
+
+            ps.expect_char('.')
+
+            key = self.get_identifier(ps)
+
+            ps.skip_line_ws()
+            ps.expect_char('=')
+            ps.skip_line_ws()
+
+            value = self.get_pattern(ps)
+
+            if value is None:
+                raise ParseError('E0006', 'value')
+
+            attrs.append(ast.Attribute(key, value))
+
+            if not ps.is_peek_next_line_attribute_start():
+                break
+        return attrs
+
+    def get_tags(self, ps):
+        tags = []
+
+        while True:
+            ps.expect_char('\n')
+            ps.skip_line_ws()
+
+            ps.expect_char('#')
+
+            symb = self.get_symbol(ps)
+
+            tags.append(ast.Tag(symb))
+
+            if not ps.is_peek_next_line_tag_start():
+                break
+        return tags
+
+    def get_identifier(self, ps):
+        name = ''
+
+        name += ps.take_id_start()
+
+        ch = ps.take_id_char()
+        while ch:
+            name += ch
+            ch = ps.take_id_char()
+
+        return ast.Identifier(name)
+
+    def get_variant_key(self, ps):
+        ch = ps.current()
+
+        if ch is None:
+            raise ParseError('E0013')
+
+        if ps.is_number_start():
+            return self.get_number(ps)
+
+        return self.get_symbol(ps)
+
+    def get_variants(self, ps):
+        variants = []
+        has_default = False
+
+        while True:
+            default_index = False
+
+            ps.expect_char('\n')
+            ps.skip_line_ws()
+
+            if ps.current_is('*'):
+                if has_default:
+                    raise ParseError('E0015')
+                ps.next()
+                default_index = True
+                has_default = True
+
+            ps.expect_char('[')
+
+            key = self.get_variant_key(ps)
+
+            ps.expect_char(']')
 
             ps.skip_line_ws()
 
-            variants = get_variants(ps)
+            value = self.get_pattern(ps)
 
-            if len(variants) == 0:
-                raise ParseError('E0011')
+            if value is None:
+                raise ParseError('E0006', 'value')
+
+            variants.append(ast.Variant(key, value, default_index))
+
+            if not ps.is_peek_next_line_variant_start():
+                break
+
+        if not has_default:
+            raise ParseError('E0010')
+
+        return variants
+
+    def get_symbol(self, ps):
+        name = ''
+
+        name += ps.take_id_start()
+
+        while True:
+            ch = ps.take_symb_char()
+            if ch:
+                name += ch
+            else:
+                break
+
+        return ast.Symbol(name.rstrip())
+
+    def get_digits(self, ps):
+        num = ''
+
+        ch = ps.take_digit()
+        while ch:
+            num += ch
+            ch = ps.take_digit()
+
+        if len(num) == 0:
+            raise ParseError('E0004', '0-9')
+
+        return num
+
+    def get_number(self, ps):
+        num = ''
+
+        if ps.current_is('-'):
+            num += '-'
+            ps.next()
+
+        num += self.get_digits(ps)
+
+        if ps.current_is('.'):
+            num += '.'
+            ps.next()
+            num += self.get_digits(ps)
+
+        return ast.NumberExpression(num)
+
+    def get_pattern(self, ps):
+        buffer = ''
+        elements = []
+        first_line = True
+
+        while ps.current():
+            ch = ps.current()
+            if ch == '\n':
+                if first_line and len(buffer) != 0:
+                    break
+
+                if not ps.is_peek_next_line_pattern():
+                    break
+
+                ps.next()
+                ps.skip_line_ws()
+
+                if not first_line:
+                    buffer += ch
+
+                first_line = False
+                continue
+            elif ch == '\\':
+                ch2 = ps.peek()
+
+                if ch2 == '{' or ch2 == '"':
+                    buffer += ch2
+                else:
+                    buffer += ch + ch2
+                ps.next()
+            elif ch == '{':
+                ps.next()
+
+                ps.skip_line_ws()
+
+                if len(buffer) != 0:
+                    elements.append(ast.TextElement(buffer))
+
+                buffer = ''
+
+                elements.append(self.get_expression(ps))
+
+                ps.expect_char('}')
+
+                continue
+            else:
+                buffer += ps.ch
+            ps.next()
+
+        if len(buffer) != 0:
+            elements.append(ast.TextElement(buffer))
+
+        return ast.Pattern(elements)
+
+    def get_expression(self, ps):
+        if ps.is_peek_next_line_variant_start():
+            variants = self.get_variants(ps)
 
             ps.expect_char('\n')
             ps.expect_char(' ')
             ps.skip_line_ws()
 
-            return ast.SelectExpression(selector, variants)
+            return ast.SelectExpression(None, variants)
 
-    return selector
+        selector = self.get_selector_expression(ps)
 
-def get_selector_expression(ps):
-    literal = get_literal(ps)
+        ps.skip_line_ws()
 
-    if not isinstance(literal, ast.MessageReference):
+        if ps.current_is('-'):
+            ps.peek()
+            if not ps.current_peek_is('>'):
+                ps.reset_peek()
+            else:
+                ps.next()
+                ps.next()
+
+                ps.skip_line_ws()
+
+                variants = self.get_variants(ps)
+
+                if len(variants) == 0:
+                    raise ParseError('E0011')
+
+                ps.expect_char('\n')
+                ps.expect_char(' ')
+                ps.skip_line_ws()
+
+                return ast.SelectExpression(selector, variants)
+
+        return selector
+
+    def get_selector_expression(self, ps):
+        literal = self.get_literal(ps)
+
+        if not isinstance(literal, ast.MessageReference):
+            return literal
+
+        ch = ps.current()
+
+        if (ch == '.'):
+            ps.next()
+            attr = self.get_identifier(ps)
+            return ast.AttributeExpression(literal.id, attr)
+
+        if (ch == '['):
+            ps.next()
+            key = self.get_variant_key(ps)
+            ps.expect_char(']')
+            return ast.VariantExpression(literal.id, key)
+
+        if (ch == '('):
+            ps.next()
+
+            args = self.get_call_args(ps)
+
+            ps.expect_char(')')
+
+            return ast.CallExpression(literal.id, args)
+
         return literal
 
-    ch = ps.current()
-
-    if (ch == '.'):
-        ps.next()
-        attr = get_identifier(ps)
-        return ast.AttributeExpression(literal.id, attr)
-
-    if (ch == '['):
-        ps.next()
-        key = get_variant_key(ps)
-        ps.expect_char(']')
-        return ast.VariantExpression(literal.id, key)
-
-    if (ch == '('):
-        ps.next()
-
-        args = get_call_args(ps)
-
-        ps.expect_char(')')
-
-        return ast.CallExpression(literal.id, args)
-
-    return literal
-
-def get_call_args(ps):
-    args = []
-
-    ps.skip_line_ws()
-
-    while True:
-        if ps.current_is(')'):
-            break
-
-        exp = get_selector_expression(ps)
+    def get_call_args(self, ps):
+        args = []
 
         ps.skip_line_ws()
 
-        if ps.current_is(':'):
-            if not isinstance(exp, ast.MessageReference):
-                raise ParseError('E0009')
+        while True:
+            if ps.current_is(')'):
+                break
 
-            ps.next()
+            exp = self.get_selector_expression(ps)
+
             ps.skip_line_ws()
 
-            val = get_arg_val(ps)
+            if ps.current_is(':'):
+                if not isinstance(exp, ast.MessageReference):
+                    raise ParseError('E0009')
 
-            args.append(ast.NamedArgument(exp.id, val))
-        else:
-            args.append(exp)
+                ps.next()
+                ps.skip_line_ws()
 
-        ps.skip_line_ws()
+                val = self.get_arg_val(ps)
 
-        if ps.current_is(','):
-            ps.next()
+                args.append(ast.NamedArgument(exp.id, val))
+            else:
+                args.append(exp)
+
             ps.skip_line_ws()
-            continue
-        else:
-            break
 
-    return args
+            if ps.current_is(','):
+                ps.next()
+                ps.skip_line_ws()
+                continue
+            else:
+                break
 
-def get_arg_val(ps):
-    if ps.is_number_start():
-        return get_number(ps)
-    elif ps.current_is('"'):
-        return get_string(ps)
-    raise ParseError('E0006', 'value')
+        return args
 
-def get_string(ps):
-    val = ''
+    def get_arg_val(self, ps):
+        if ps.is_number_start():
+            return self.get_number(ps)
+        elif ps.current_is('"'):
+            return self.get_string(ps)
+        raise ParseError('E0006', 'value')
 
-    ps.expect_char('"')
+    def get_string(self, ps):
+        val = ''
 
-    ch = ps.take_char(lambda x: x != '"')
-    while ch:
-        val += ch
+        ps.expect_char('"')
+
         ch = ps.take_char(lambda x: x != '"')
+        while ch:
+            val += ch
+            ch = ps.take_char(lambda x: x != '"')
 
-    ps.next()
-
-    return ast.StringExpression(val)
-
-def get_literal(ps):
-    ch = ps.current()
-
-    if ch is None:
-        raise ParseError('E0014')
-
-    if ps.is_number_start():
-        return get_number(ps)
-    elif ch == '"':
-        return get_string(ps)
-    elif ch == '$':
         ps.next()
-        name = get_identifier(ps)
-        return ast.ExternalArgument(name)
 
-    name = get_identifier(ps)
-    return ast.MessageReference(name)
+        return ast.StringExpression(val)
+
+    def get_literal(self, ps):
+        ch = ps.current()
+
+        if ch is None:
+            raise ParseError('E0014')
+
+        if ps.is_number_start():
+            return self.get_number(ps)
+        elif ch == '"':
+            return self.get_string(ps)
+        elif ch == '$':
+            ps.next()
+            name = self.get_identifier(ps)
+            return ast.ExternalArgument(name)
+
+        name = self.get_identifier(ps)
+        return ast.MessageReference(name)

--- a/fluent/util.py
+++ b/fluent/util.py
@@ -32,7 +32,7 @@ def fold(fun, node, init):
         head = list(vals)[0]
         tail = list(vals)[1:]
 
-        if isinstance(head, FTL.Node):
+        if isinstance(head, FTL.BaseNode):
             acc = fold(fun, head, acc)
         if isinstance(head, list):
             acc = fold_(head, acc)

--- a/tests/syntax/fixtures_structure/message_with_empty_pattern.json
+++ b/tests/syntax/fixtures_structure/message_with_empty_pattern.json
@@ -3,24 +3,39 @@
   "body": [
     {
       "type": "Message",
+      "annotations": [],
+      "id": {
+        "type": "Identifier",
+        "name": "foo",
+        "span": {
+          "type": "Span",
+          "start": 0,
+          "end": 3
+        }
+      },
+      "value": {
+        "type": "Pattern",
+        "elements": [],
+        "span": {
+          "type": "Span",
+          "start": 6,
+          "end": 6
+        }
+      },
+      "attributes": [],
+      "tags": [],
+      "comment": null,
       "span": {
         "type": "Span",
         "start": 0,
         "end": 6
-      },
-      "annotations": [],
-      "id": {
-        "type": "Identifier",
-        "name": "foo"
-      },
-      "value": {
-        "type": "Pattern",
-        "elements": []
-      },
-      "attributes": null,
-      "tags": null,
-      "comment": null
+      }
     }
   ],
-  "comment": null
+  "comment": null,
+  "span": {
+    "type": "Span",
+    "start": 0,
+    "end": 7
+  }
 }

--- a/tests/syntax/fixtures_structure/placeable_at_eol.json
+++ b/tests/syntax/fixtures_structure/placeable_at_eol.json
@@ -3,40 +3,75 @@
   "body": [
     {
       "type": "Message",
-      "span": {
-        "type": "Span",
-        "start": 0,
-        "end": 130
-      },
       "annotations": [],
       "id": {
         "type": "Identifier",
-        "name": "key"
+        "name": "key",
+        "span": {
+          "type": "Span",
+          "start": 0,
+          "end": 3
+        }
       },
       "value": {
         "type": "Pattern",
         "elements": [
           {
             "type": "TextElement",
-            "value": "A multiline message with a "
+            "value": "A multiline message with a ",
+            "span": {
+              "type": "Span",
+              "start": 5,
+              "end": 39
+            }
           },
           {
             "type": "MessageReference",
             "id": {
               "type": "Identifier",
-              "name": "placeable"
+              "name": "placeable",
+              "span": {
+                "type": "Span",
+                "start": 39,
+                "end": 48
+              }
+            },
+            "span": {
+              "type": "Span",
+              "start": 39,
+              "end": 48
             }
           },
           {
             "type": "TextElement",
-            "value": "\nat the end of line.  The message should\nconsist of three lines of text."
+            "value": "\nat the end of line.  The message should\nconsist of three lines of text.",
+            "span": {
+              "type": "Span",
+              "start": 50,
+              "end": 130
+            }
           }
-        ]
+        ],
+        "span": {
+          "type": "Span",
+          "start": 5,
+          "end": 130
+        }
       },
-      "attributes": null,
-      "tags": null,
-      "comment": null
+      "attributes": [],
+      "tags": [],
+      "comment": null,
+      "span": {
+        "type": "Span",
+        "start": 0,
+        "end": 130
+      }
     }
   ],
-  "comment": null
+  "comment": null,
+  "span": {
+    "type": "Span",
+    "start": 0,
+    "end": 131
+  }
 }

--- a/tests/syntax/fixtures_structure/resource_comment.json
+++ b/tests/syntax/fixtures_structure/resource_comment.json
@@ -3,12 +3,17 @@
   "body": [],
   "comment": {
     "type": "Comment",
+    "annotations": [],
+    "content": "This is a resource wide comment\nIt's multiline",
     "span": {
       "type": "Span",
       "start": 0,
       "end": 53
-    },
-    "annotations": [],
-    "content": "This is a resource wide comment\nIt's multiline"
+    }
+  },
+  "span": {
+    "type": "Span",
+    "start": 0,
+    "end": 53
   }
 }

--- a/tests/syntax/fixtures_structure/resource_comment_trailing_line.json
+++ b/tests/syntax/fixtures_structure/resource_comment_trailing_line.json
@@ -3,12 +3,17 @@
   "body": [],
   "comment": {
     "type": "Comment",
+    "annotations": [],
+    "content": "This is a comment\nThis comment is multiline\n",
     "span": {
       "type": "Span",
       "start": 0,
       "end": 53
-    },
-    "annotations": [],
-    "content": "This is a comment\nThis comment is multiline\n"
+    }
+  },
+  "span": {
+    "type": "Span",
+    "start": 0,
+    "end": 53
   }
 }

--- a/tests/syntax/fixtures_structure/section.json
+++ b/tests/syntax/fixtures_structure/section.json
@@ -3,18 +3,28 @@
   "body": [
     {
       "type": "Section",
+      "annotations": [],
+      "name": {
+        "type": "Symbol",
+        "name": "This is a section",
+        "span": {
+          "type": "Span",
+          "start": 4,
+          "end": 22
+        }
+      },
+      "comment": null,
       "span": {
         "type": "Span",
         "start": 1,
         "end": 25
-      },
-      "annotations": [],
-      "name": {
-        "type": "Symbol",
-        "name": "This is a section"
-      },
-      "comment": null
+      }
     }
   ],
-  "comment": null
+  "comment": null,
+  "span": {
+    "type": "Span",
+    "start": 0,
+    "end": 25
+  }
 }

--- a/tests/syntax/fixtures_structure/simple_message.json
+++ b/tests/syntax/fixtures_structure/simple_message.json
@@ -3,29 +3,49 @@
   "body": [
     {
       "type": "Message",
-      "span": {
-        "type": "Span",
-        "start": 0,
-        "end": 9
-      },
       "annotations": [],
       "id": {
         "type": "Identifier",
-        "name": "foo"
+        "name": "foo",
+        "span": {
+          "type": "Span",
+          "start": 0,
+          "end": 3
+        }
       },
       "value": {
         "type": "Pattern",
         "elements": [
           {
             "type": "TextElement",
-            "value": "Foo"
+            "value": "Foo",
+            "span": {
+              "type": "Span",
+              "start": 6,
+              "end": 9
+            }
           }
-        ]
+        ],
+        "span": {
+          "type": "Span",
+          "start": 6,
+          "end": 9
+        }
       },
-      "attributes": null,
-      "tags": null,
-      "comment": null
+      "attributes": [],
+      "tags": [],
+      "comment": null,
+      "span": {
+        "type": "Span",
+        "start": 0,
+        "end": 9
+      }
     }
   ],
-  "comment": null
+  "comment": null,
+  "span": {
+    "type": "Span",
+    "start": 0,
+    "end": 10
+  }
 }

--- a/tests/syntax/fixtures_structure/standalone_comment.json
+++ b/tests/syntax/fixtures_structure/standalone_comment.json
@@ -3,39 +3,59 @@
   "body": [
     {
       "type": "Message",
-      "span": {
-        "type": "Span",
-        "start": 0,
-        "end": 11
-      },
       "annotations": [],
       "id": {
         "type": "Identifier",
-        "name": "foo"
+        "name": "foo",
+        "span": {
+          "type": "Span",
+          "start": 0,
+          "end": 3
+        }
       },
       "value": {
         "type": "Pattern",
         "elements": [
           {
             "type": "TextElement",
-            "value": "Value"
+            "value": "Value",
+            "span": {
+              "type": "Span",
+              "start": 6,
+              "end": 11
+            }
           }
-        ]
+        ],
+        "span": {
+          "type": "Span",
+          "start": 6,
+          "end": 11
+        }
       },
-      "attributes": null,
-      "tags": null,
-      "comment": null
+      "attributes": [],
+      "tags": [],
+      "comment": null,
+      "span": {
+        "type": "Span",
+        "start": 0,
+        "end": 11
+      }
     },
     {
       "type": "Comment",
+      "annotations": [],
+      "content": "This is a standalone comment",
       "span": {
         "type": "Span",
         "start": 13,
         "end": 45
-      },
-      "annotations": [],
-      "content": "This is a standalone comment"
+      }
     }
   ],
-  "comment": null
+  "comment": null,
+  "span": {
+    "type": "Span",
+    "start": 0,
+    "end": 45
+  }
 }

--- a/tests/syntax/test_ast_json.py
+++ b/tests/syntax/test_ast_json.py
@@ -10,6 +10,8 @@ from fluent.syntax.parser import FluentParser
 
 
 class TestASTJSON(unittest.TestCase):
+    maxDiff = None
+
     def setUp(self):
         self.parser = FluentParser()
 

--- a/tests/syntax/test_behavior.py
+++ b/tests/syntax/test_behavior.py
@@ -100,4 +100,6 @@ class TestBehaviorMeta(type):
 
 
 class TestBehavior(unittest.TestCase):
+    maxDiff = None
+
     __metaclass__ = TestBehaviorMeta

--- a/tests/syntax/test_entry.py
+++ b/tests/syntax/test_entry.py
@@ -11,6 +11,8 @@ from fluent.syntax.serializer import FluentSerializer
 
 
 class TestParseEntry(unittest.TestCase):
+    maxDiff = None
+
     def setUp(self):
         self.parser = FluentParser()
 
@@ -25,22 +27,37 @@ class TestParseEntry(unittest.TestCase):
                 "end": 9,
                 "type": "Span"
             },
-            "tags": None,
+            "tags": [],
             "value": {
                 "elements": [
                     {
                         "type": "TextElement",
-                        "value": "Foo"
+                        "value": "Foo",
+                        "span": {
+                            "start": 6,
+                            "end": 9,
+                            "type": "Span"
+                        }
                     }
                 ],
-                "type": "Pattern"
+                "type": "Pattern",
+                "span": {
+                    "start": 6,
+                    "end": 9,
+                    "type": "Span"
+                }
             },
             "annotations": [],
-            "attributes": None,
+            "attributes": [],
             "type": "Message",
             "id": {
                 "type": "Identifier",
-                "name": "foo"
+                "name": "foo",
+                "span": {
+                    "start": 0,
+                    "end": 3,
+                    "type": "Span"
+                }
             }
         }
 
@@ -60,7 +77,7 @@ class TestSerializeEntry(unittest.TestCase):
                 "end": 9,
                 "type": "Span"
             },
-            "tags": None,
+            "tags": [],
             "value": {
                 "elements": [
                     {
@@ -71,7 +88,7 @@ class TestSerializeEntry(unittest.TestCase):
                 "type": "Pattern"
             },
             "annotations": [],
-            "attributes": None,
+            "attributes": [],
             "type": "Message",
             "id": {
                 "type": "Identifier",

--- a/tests/syntax/test_structure.py
+++ b/tests/syntax/test_structure.py
@@ -51,4 +51,6 @@ class TestStructureMeta(type):
 
 
 class TestStructure(unittest.TestCase):
+    maxDiff = None
+
     __metaclass__ = TestStructureMeta


### PR DESCRIPTION
Most AST nodes can now have a Span. Use `FluentParser(with_spans=True)` to enable this behavior.  The `with_annotations` config option to `FluentParser` has been removed. The parser always produces Annotations if necessary now.