### PR TITLE
Compare locales bug 1382622

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,11 @@
+sudo: false
 language: python
 python:
   - "2.7"
   - "3.5"
   - "nightly"
-script: python -m unittest discover
+install: pip install tox-travis
+script: tox
 notifications:
   irc:
     channels:

--- a/tests/migrate/test_concat.py
+++ b/tests/migrate/test_concat.py
@@ -20,7 +20,7 @@ from fluent.migrate.transforms import (
 
 class MockContext(unittest.TestCase):
     def get_source(self, path, key):
-        return self.strings.get(key, None).get_val()
+        return self.strings.get(key, None).val
 
 
 @unittest.skipUnless(PropertiesParser, 'compare-locales required')

--- a/tests/migrate/test_literal.py
+++ b/tests/migrate/test_literal.py
@@ -15,7 +15,7 @@ from fluent.migrate.transforms import evaluate, COPY
 
 class MockContext(unittest.TestCase):
     def get_source(self, path, key):
-        return self.strings.get(key, None).get_val()
+        return self.strings.get(key, None).val
 
 
 @unittest.skipUnless(PropertiesParser, 'compare-locales required')

--- a/tests/migrate/test_merge.py
+++ b/tests/migrate/test_merge.py
@@ -18,7 +18,7 @@ from fluent.migrate.transforms import COPY
 
 class MockContext(unittest.TestCase):
     def get_source(self, path, key):
-        return self.ab_cd_legacy.get(key, None).get_val()
+        return self.ab_cd_legacy.get(key, None).val
 
 
 @unittest.skipUnless(PropertiesParser and DTDParser,

--- a/tests/migrate/test_plural.py
+++ b/tests/migrate/test_plural.py
@@ -19,7 +19,7 @@ class MockContext(unittest.TestCase):
     plural_categories = ('one', 'other')
 
     def get_source(self, path, key):
-        return self.strings.get(key, None).get_val()
+        return self.strings.get(key, None).val
 
 
 @unittest.skipUnless(PropertiesParser, 'compare-locales required')

--- a/tests/migrate/test_replace.py
+++ b/tests/migrate/test_replace.py
@@ -16,7 +16,7 @@ from fluent.migrate.transforms import evaluate, REPLACE
 
 class MockContext(unittest.TestCase):
     def get_source(self, path, key):
-        return self.strings.get(key, None).get_val()
+        return self.strings.get(key, None).val
 
 
 @unittest.skipUnless(PropertiesParser, 'compare-locales required')

--- a/tox.ini
+++ b/tox.ini
@@ -1,8 +1,11 @@
 [tox]
-envlist = py27, py36
+envlist = py27, py27-cl, py36
 skipsdist=True
 
 [testenv]
 setenv =
     PYTHONPATH = {toxinidir}
+deps =
+    cl: compare-locales
+
 commands=python -m unittest discover


### PR DESCRIPTION
Add testing for python 2.7 with compare-locales and without. As compare-locales doesn't support py3, we don't do that for 3.6 yet.

The test failures were just in the actual test code, so this fix is low-impact.