### PR TITLE
Bug 1366298 - Skip SelectExpression in PLURALS for one plural category

### DIFF
--- a/fluent/migrate/transforms.py
+++ b/fluent/migrate/transforms.py
@@ -236,6 +236,13 @@ class PLURALS(Source):
         selector = evaluate(ctx, self.selector)
         variants = value.split(';')
         keys = ctx.plural_categories
+
+        # A special case for languages with one plural category. We don't need
+        # to insert a SelectExpression at all for them.
+        if len(keys) == len(variants) == 1:
+            variant, = variants
+            return evaluate(ctx, self.foreach(variant))
+
         last_index = min(len(variants), len(keys)) - 1
 
         def createVariant(zipped_enum):

--- a/tests/migrate/test_plural.py
+++ b/tests/migrate/test_plural.py
@@ -15,7 +15,8 @@ from fluent.migrate.transforms import evaluate, PLURALS, REPLACE_IN_TEXT
 
 
 class MockContext(unittest.TestCase):
-    # Static categories corresponding to en-US.
+    maxDiff = None
+    # Plural categories corresponding to English (en-US).
     plural_categories = ('one', 'other')
 
     def get_source(self, path, key):
@@ -137,6 +138,82 @@ class TestPluralReplace(MockContext):
                     { $num ->
                         [one] Delete this download?
                        *[other] Delete { $num } downloads?
+                    }
+            ''')
+        )
+
+
+@unittest.skipUnless(PropertiesParser, 'compare-locales required')
+class TestOneCategory(MockContext):
+    # Plural categories corresponding to Turkish (tr).
+    plural_categories = ('other',)
+
+    def setUp(self):
+        self.strings = parse(PropertiesParser, '''
+            deleteAll=#1 indirme silinsin mi?
+        ''')
+
+        self.message = FTL.Message(
+            FTL.Identifier('delete-all'),
+            value=PLURALS(
+                'test.properties',
+                'deleteAll',
+                EXTERNAL_ARGUMENT('num'),
+                lambda text: REPLACE_IN_TEXT(
+                    text,
+                    {
+                        '#1': EXTERNAL_ARGUMENT('num')
+                    }
+                )
+            )
+        )
+
+    def test_no_select_expression(self):
+        self.assertEqual(
+            evaluate(self, self.message).to_json(),
+            ftl_message_to_json('''
+                delete-all = { $num } indirme silinsin mi?
+            ''')
+        )
+
+
+@unittest.skipUnless(PropertiesParser, 'compare-locales required')
+class TestManyCategories(MockContext):
+    # Plural categories corresponding to Polish (pl).
+    plural_categories = ('one', 'few', 'many', 'other')
+
+    def setUp(self):
+        self.strings = parse(PropertiesParser, '''
+            deleteAll=Usunąć plik?;Usunąć #1 pliki?;Usunąć #1 plików?
+        ''')
+
+        self.message = FTL.Message(
+            FTL.Identifier('delete-all'),
+            value=PLURALS(
+                'test.properties',
+                'deleteAll',
+                EXTERNAL_ARGUMENT('num'),
+                lambda text: REPLACE_IN_TEXT(
+                    text,
+                    {
+                        '#1': EXTERNAL_ARGUMENT('num')
+                    }
+                )
+            )
+        )
+
+    def test_too_few_variants(self):
+        # StringBundle's plural rule #9 used for Polish has three categories
+        # which is one fewer than the CLDR's. The migrated string will not have
+        # the [other] variant and [many] will be marked as the default.
+        self.assertEqual(
+            evaluate(self, self.message).to_json(),
+            ftl_message_to_json('''
+                delete-all =
+                    { $num ->
+                        [one] Usunąć plik?
+                        [few] Usunąć { $num } pliki?
+                       *[many] Usunąć { $num } plików?
                     }
             ''')
         )


### PR DESCRIPTION
https://bugzilla.mozilla.org/show_bug.cgi?id=1366298

Languages with one plural category can have their translations migrated
directly to a single `Pattern` rather than a `SelectExpression` with one
variant. This will only happen when the number of variants in the
legacy translation is also one.

This also adds tests for languages with more categories than en-US.