### PR TITLE
Bug 1420225 - Read legacy files when scanning for Sources in transforms

### DIFF
--- a/tests/migrate/test_context.py
+++ b/tests/migrate/test_context.py
@@ -5,6 +5,11 @@ import os
 import logging
 import unittest
 
+try:
+    import compare_locales
+except ImportError:
+    compare_locales = None
+
 import fluent.syntax.ast as FTL
 
 from fluent.migrate.errors import NotSupportedError, UnreadableReferenceError
@@ -18,6 +23,7 @@ def here(*parts):
     return os.path.join(dirname, *parts)
 
 
+@unittest.skipUnless(compare_locales, 'compare-locales requried')
 class TestMergeContext(unittest.TestCase):
     def setUp(self):
         self.ctx = MergeContext(
@@ -25,12 +31,6 @@ class TestMergeContext(unittest.TestCase):
             reference_dir=here('fixtures/en-US'),
             localization_dir=here('fixtures/pl')
         )
-
-        try:
-            self.ctx.maybe_add_localization('aboutDownloads.dtd')
-            self.ctx.maybe_add_localization('aboutDownloads.properties')
-        except RuntimeError:
-            self.skipTest('compare-locales required')
 
     def test_hardcoded_node(self):
         self.ctx.add_transforms('aboutDownloads.ftl', 'aboutDownloads.ftl', [
@@ -249,6 +249,7 @@ class TestIncompleteReference(unittest.TestCase):
             self.ctx.add_transforms('some.ftl', 'missing.ftl', [])
 
 
+@unittest.skipUnless(compare_locales, 'compare-locales requried')
 class TestIncompleteLocalization(unittest.TestCase):
     def setUp(self):
         # Silence all logging.
@@ -259,11 +260,6 @@ class TestIncompleteLocalization(unittest.TestCase):
             reference_dir=here('fixtures/en-US'),
             localization_dir=here('fixtures/pl')
         )
-
-        try:
-            self.ctx.maybe_add_localization('browser.dtd')
-        except RuntimeError:
-            self.skipTest('compare-locales required')
 
         self.ctx.add_transforms('toolbar.ftl', 'toolbar.ftl', [
             FTL.Message(
@@ -299,6 +295,7 @@ class TestIncompleteLocalization(unittest.TestCase):
         )
 
 
+@unittest.skipUnless(compare_locales, 'compare-locales requried')
 class TestExistingTarget(unittest.TestCase):
     maxDiff = None
 
@@ -311,11 +308,6 @@ class TestExistingTarget(unittest.TestCase):
             reference_dir=here('fixtures/en-US'),
             localization_dir=here('fixtures/pl')
         )
-
-        try:
-            self.ctx.maybe_add_localization('privacy.dtd')
-        except RuntimeError:
-            self.skipTest('compare-locales required')
 
     def tearDown(self):
         # Resume logging.

--- a/tests/migrate/test_context_real_examples.py
+++ b/tests/migrate/test_context_real_examples.py
@@ -4,6 +4,11 @@ from __future__ import unicode_literals
 import os
 import unittest
 
+try:
+    import compare_locales
+except ImportError:
+    compare_locales = None
+
 import fluent.syntax.ast as FTL
 
 from fluent.migrate.util import ftl_resource_to_json, to_json
@@ -19,6 +24,7 @@ def here(*parts):
     return os.path.join(dirname, *parts)
 
 
+@unittest.skipUnless(compare_locales, 'compare-locales requried')
 class TestMergeAboutDownloads(unittest.TestCase):
     def setUp(self):
         self.ctx = MergeContext(
@@ -26,12 +32,6 @@ class TestMergeAboutDownloads(unittest.TestCase):
             reference_dir=here('fixtures/en-US'),
             localization_dir=here('fixtures/pl')
         )
-
-        try:
-            self.ctx.maybe_add_localization('aboutDownloads.dtd')
-            self.ctx.maybe_add_localization('aboutDownloads.properties')
-        except RuntimeError:
-            self.skipTest('compare-locales required')
 
         self.ctx.add_transforms('aboutDownloads.ftl', 'aboutDownloads.ftl', [
             FTL.Message(
@@ -279,6 +279,7 @@ class TestMergeAboutDownloads(unittest.TestCase):
         )
 
 
+@unittest.skipUnless(compare_locales, 'compare-locales requried')
 class TestMergeAboutDialog(unittest.TestCase):
     def setUp(self):
         self.ctx = MergeContext(
@@ -286,11 +287,6 @@ class TestMergeAboutDialog(unittest.TestCase):
             reference_dir=here('fixtures/en-US'),
             localization_dir=here('fixtures/pl')
         )
-
-        try:
-            self.ctx.maybe_add_localization('aboutDialog.dtd')
-        except RuntimeError:
-            self.skipTest('compare-locales required')
 
         self.ctx.add_transforms('aboutDialog.ftl', 'aboutDialog.ftl', [
             FTL.Message(

--- a/tools/migrate/examples/about_dialog.py
+++ b/tools/migrate/examples/about_dialog.py
@@ -9,8 +9,6 @@ from fluent.migrate import (
 def migrate(ctx):
     """Migrate about:dialog, part {index}"""
 
-    ctx.maybe_add_localization('browser/chrome/browser/aboutDialog.dtd')
-
     ctx.add_transforms('browser/about_dialog.ftl', 'about_dialog.ftl', [
         FTL.Message(
             id=FTL.Identifier('update-failed'),

--- a/tools/migrate/examples/about_downloads.py
+++ b/tools/migrate/examples/about_downloads.py
@@ -7,11 +7,6 @@ from fluent.migrate import EXTERNAL_ARGUMENT, COPY, PLURALS, REPLACE_IN_TEXT
 def migrate(ctx):
     """Migrate about:download in Firefox for Android, part {index}"""
 
-    ctx.maybe_add_localization(
-        'mobile/android/chrome/aboutDownloads.dtd')
-    ctx.maybe_add_localization(
-        'mobile/android/chrome/aboutDownloads.properties')
-
     ctx.add_transforms('mobile/about_downloads.ftl', 'about_downloads.ftl', [
         FTL.Message(
             id=FTL.Identifier('title'),

--- a/tools/migrate/examples/bug_1291693.py
+++ b/tools/migrate/examples/bug_1291693.py
@@ -7,11 +7,6 @@ from fluent.migrate import MESSAGE_REFERENCE, COPY, REPLACE
 def migrate(ctx):
     """Bug 1291693 - Migrate the menubar to FTL, part {index}"""
 
-    ctx.maybe_add_localization('browser/chrome/browser/browser.dtd')
-    ctx.maybe_add_localization('browser/chrome/browser/browser.properties')
-    ctx.maybe_add_localization('browser/branding/official/brand.dtd')
-    ctx.maybe_add_localization('browser/branding/official/brand.properties')
-
     ctx.add_transforms('browser/menubar.ftl', 'menubar.ftl', [
         FTL.Message(
             id=FTL.Identifier('file-menu'),


### PR DESCRIPTION
https://bugzilla.mozilla.org/show_bug.cgi?id=1420225

This is a simple change which makes it unnecessary to use `maybe_add_localization`—at all.