### PR TITLE
Do not require args when creating a CallExpression

### DIFF
--- a/fluent/syntax/ast.py
+++ b/fluent/syntax/ast.py
@@ -246,10 +246,10 @@ class VariantExpression(Expression):
         self.key = key
 
 class CallExpression(Expression):
-    def __init__(self, callee, args, **kwargs):
+    def __init__(self, callee, args=None, **kwargs):
         super(CallExpression, self).__init__(**kwargs)
         self.callee = callee
-        self.args = args
+        self.args = args or []
 
 class Attribute(SyntaxNode):
     def __init__(self, id, value, **kwargs):


### PR DESCRIPTION
While working on https://bugzilla.mozilla.org/show_bug.cgi?id=1424682 I noticed that it's not possible to create a `CallExpression` without passing args, even if empty.

I think it'll be pretty common in migration code to want to call `FTL.CallExpression("PLATFORM")` etc.