### PR TITLE
Never migrate partial translations

### DIFF
--- a/tests/migrate/test_context_real_examples.py
+++ b/tests/migrate/test_context_real_examples.py
@@ -281,6 +281,8 @@ class TestMergeAboutDownloads(unittest.TestCase):
 
 @unittest.skipUnless(compare_locales, 'compare-locales requried')
 class TestMergeAboutDialog(unittest.TestCase):
+    maxDiff = None
+
     def setUp(self):
         self.ctx = MergeContext(
             lang='pl',
@@ -363,6 +365,8 @@ class TestMergeAboutDialog(unittest.TestCase):
     def test_merge_context_some_messages(self):
         changeset = {
             ('aboutDialog.dtd', 'update.failed.start'),
+            ('aboutDialog.dtd', 'update.failed.linkText'),
+            ('aboutDialog.dtd', 'update.failed.end'),
         }
 
         expected = {
@@ -378,4 +382,15 @@ class TestMergeAboutDialog(unittest.TestCase):
         self.assertDictEqual(
             to_json(self.ctx.merge_changeset(changeset)),
             expected
+        )
+
+    def test_merge_context_too_few_messages(self):
+        changeset = {
+            ('aboutDialog.dtd', 'update.failed.start'),
+            ('aboutDialog.dtd', 'update.failed.linkText'),
+        }
+
+        self.assertDictEqual(
+            to_json(self.ctx.merge_changeset(changeset)),
+            {}
         )

--- a/tests/migrate/test_merge.py
+++ b/tests/migrate/test_merge.py
@@ -19,12 +19,17 @@ class MockContext(unittest.TestCase):
     def get_source(self, path, key):
         # Ignore path (test.properties) and get translations from
         # self.ab_cd_legacy defined in setUp.
-        return self.ab_cd_legacy.get(key, None).val
+        translation = self.ab_cd_legacy.get(key, None)
+
+        if translation is not None:
+            return translation.val
 
 
 @unittest.skipUnless(PropertiesParser and DTDParser,
                      'compare-locales required')
 class TestMergeMessages(MockContext):
+    maxDiff = None
+
     def setUp(self):
         self.en_us_ftl = parse(FluentParser, ftl('''
             title  = Downloads


### PR DESCRIPTION
Partial translations may break the AST because they produce `TextElements` with `None` values. For now, explicitly skip any transforms which depend on at least one missing legacy string.

In the future we might be able to allow partial migrations in some situations, like migrating a subset of attributes of a message. See https://bugzilla.mozilla.org/show_bug.cgi?id=1321271.