### PR TITLE
Allow CONCAT(*elements) and CONCAT(elements=[…])

### DIFF
--- a/fluent/syntax/ast.py
+++ b/fluent/syntax/ast.py
@@ -66,12 +66,10 @@ class BaseNode(object):
             else:
                 return fun(value)
 
+        # Use all attributes found on the node as kwargs to the constructor.
+        kwargs = vars(self).items()
         node = self.__class__(
-            **{
-                name: visit(value)
-                for name, value in vars(self).items()
-            }
-        )
+            **{name: visit(value) for name, value in kwargs})
 
         return fun(node)
 

--- a/tests/migrate/test_concat.py
+++ b/tests/migrate/test_concat.py
@@ -157,12 +157,29 @@ class TestConcatInterpolate(MockContext):
             <!ENTITY channel.description.end    " channel.">
         ''')
 
-    def test_concat_replace(self):
+    def test_concat_placeable(self):
         msg = FTL.Message(
             FTL.Identifier('channel-desc'),
             value=CONCAT(
                 COPY('test.properties', 'channel.description.start'),
                 FTL.Placeable(EXTERNAL_ARGUMENT('channelname')),
+                COPY('test.properties', 'channel.description.end'),
+            )
+        )
+
+        self.assertEqual(
+            evaluate(self, msg).to_json(),
+            ftl_message_to_json('''
+                channel-desc = You are on the { $channelname } channel.
+            ''')
+        )
+
+    def test_concat_expression(self):
+        msg = FTL.Message(
+            FTL.Identifier('channel-desc'),
+            value=CONCAT(
+                COPY('test.properties', 'channel.description.start'),
+                EXTERNAL_ARGUMENT('channelname'),
                 COPY('test.properties', 'channel.description.end'),
             )
         )

--- a/tests/migrate/test_util.py
+++ b/tests/migrate/test_util.py
@@ -27,11 +27,11 @@ class TestTraverse(unittest.TestCase):
         result = node.traverse(lambda x: x)
 
         self.assertEqual(
-            result.value.patterns[0].key,
+            result.value.elements[0].key,
             'key1'
         )
         self.assertEqual(
-            result.value.patterns[1].key,
+            result.value.elements[1].key,
             'key2'
         )
 


### PR DESCRIPTION
`CONCAT` used to override `FTL.BaseNode.traverse` and `FTL.BaseNode.to_json` because of its use of the `*elements` varargs in `__init__`.

Overriding `to_json` isn't required because the base mathod already supports lists.

<del>For traverse, I refactored the code slightly to only really override what's absolutely required to reconstruct an instance of CONCAT in traverse. The new BaseNode.get_init_args method returns a tuple of (args, kwargs) which can be used to programmatically create a new instance of the same class.</del>

<ins>For traverse, we allow CONCAT to be constructed with both the *elements varargs (useful when writing migration specs) and with the elements=[…] keyword arg (used by traverse because elements is an attribute of CONCAT instances).</ins>