### PR TITLE
Only expose the basic transforms from fluent.migrate

### DIFF
--- a/fluent/migrate/__init__.py
+++ b/fluent/migrate/__init__.py
@@ -1,13 +1,5 @@
 # coding=utf8
 
-from .context import MergeContext                      # noqa: F401
-from .errors import (                                  # noqa: F401
-    MigrationError, NotSupportedError, UnreadableReferenceError
-)
 from .transforms import (                              # noqa: F401
-    Source, COPY, REPLACE_IN_TEXT, REPLACE, PLURALS, CONCAT
+    CONCAT, COPY, PLURALS, REPLACE, REPLACE_IN_TEXT
 )
-from .helpers import (                                 # noqa: F401
-    EXTERNAL_ARGUMENT, MESSAGE_REFERENCE
-)
-from .changesets import convert_blame_to_changesets    # noqa: F401

--- a/tools/migrate/examples/about_dialog.py
+++ b/tools/migrate/examples/about_dialog.py
@@ -1,9 +1,8 @@
 # coding=utf8
 
 import fluent.syntax.ast as FTL
-from fluent.migrate import (
-    CONCAT, EXTERNAL_ARGUMENT, MESSAGE_REFERENCE, COPY, REPLACE
-)
+from fluent.migrate import CONCAT, COPY, REPLACE
+from fluent.migrate.helpers import EXTERNAL_ARGUMENT, MESSAGE_REFERENCE
 
 
 def migrate(ctx):

--- a/tools/migrate/examples/about_downloads.py
+++ b/tools/migrate/examples/about_downloads.py
@@ -1,7 +1,8 @@
 # coding=utf8
 
 import fluent.syntax.ast as FTL
-from fluent.migrate import EXTERNAL_ARGUMENT, COPY, PLURALS, REPLACE_IN_TEXT
+from fluent.migrate import COPY, PLURALS, REPLACE_IN_TEXT
+from fluent.migrate.helpers import EXTERNAL_ARGUMENT
 
 
 def migrate(ctx):

--- a/tools/migrate/examples/bug_1291693.py
+++ b/tools/migrate/examples/bug_1291693.py
@@ -1,7 +1,8 @@
 # coding=utf8
 
 import fluent.syntax.ast as FTL
-from fluent.migrate import MESSAGE_REFERENCE, COPY, REPLACE
+from fluent.migrate import COPY, REPLACE
+from fluent.migrate.helpers import MESSAGE_REFERENCE
 
 
 def migrate(ctx):

--- a/tools/migrate/migrate-l10n.py
+++ b/tools/migrate/migrate-l10n.py
@@ -11,9 +11,9 @@ import importlib
 import hglib
 from hglib.util import b
 
-from fluent.migrate import (
-    MergeContext, MigrationError, convert_blame_to_changesets
-)
+from fluent.migrate.context import MergeContext
+from fluent.migrate.errors import MigrationError
+from fluent.migrate.changesets import convert_blame_to_changesets
 from blame import Blame
 
 


### PR DESCRIPTION
When writing Fluent migration specs, only the transforms like `CONCAT`, `COPY`, `PLURALS` and `REPLACE` are really required. All other exports are either helpers or specific to tools/migrate/migrate-l10n.py.

Fixes #43.