### PR TITLE
Require compare-locales in fluent.migrate

### DIFF
--- a/fluent/migrate/context.py
+++ b/fluent/migrate/context.py
@@ -14,11 +14,7 @@ import fluent.syntax.ast as FTL
 from fluent.syntax.parser import FluentParser
 from fluent.syntax.serializer import FluentSerializer
 from fluent.util import fold
-try:
-    from compare_locales.parser import getParser
-except ImportError:
-    def getParser(path):
-        raise RuntimeError('compare-locales required')
+from compare_locales.parser import getParser
 
 from .cldr import get_plural_categories
 from .transforms import Source

--- a/setup.py
+++ b/setup.py
@@ -21,5 +21,6 @@ setup(name='fluent',
       package_data={
           'fluent.migrate': ['cldr_data/*']
       },
-      tests_require=['six']
+      tests_require=['six'],
+      test_suite='tests.syntax'
 )

--- a/tests/migrate/test_concat.py
+++ b/tests/migrate/test_concat.py
@@ -2,13 +2,9 @@
 from __future__ import unicode_literals
 
 import unittest
+from compare_locales.parser import PropertiesParser, DTDParser
 
 import fluent.syntax.ast as FTL
-try:
-    from compare_locales.parser import PropertiesParser, DTDParser
-except ImportError:
-    DTDParser = PropertiesParser = None
-
 from fluent.migrate.util import parse, ftl_message_to_json
 from fluent.migrate.helpers import EXTERNAL_ARGUMENT, MESSAGE_REFERENCE
 from fluent.migrate.transforms import evaluate, CONCAT, COPY, REPLACE
@@ -23,7 +19,6 @@ class MockContext(unittest.TestCase):
         return self.strings.get(key, None).val
 
 
-@unittest.skipUnless(PropertiesParser, 'compare-locales required')
 class TestConcatCopy(MockContext):
     def setUp(self):
         self.strings = parse(PropertiesParser, '''
@@ -120,7 +115,6 @@ class TestConcatCopy(MockContext):
         )
 
 
-@unittest.skipUnless(DTDParser, 'compare-locales required')
 class TestConcatLiteral(MockContext):
     def setUp(self):
         self.strings = parse(DTDParser, '''
@@ -149,7 +143,6 @@ class TestConcatLiteral(MockContext):
         )
 
 
-@unittest.skipUnless(DTDParser, 'compare-locales required')
 class TestConcatInterpolate(MockContext):
     def setUp(self):
         self.strings = parse(DTDParser, '''
@@ -192,7 +185,6 @@ class TestConcatInterpolate(MockContext):
         )
 
 
-@unittest.skipUnless(DTDParser, 'compare-locales required')
 class TestConcatReplace(MockContext):
     def setUp(self):
         self.strings = parse(DTDParser, '''

--- a/tests/migrate/test_context.py
+++ b/tests/migrate/test_context.py
@@ -4,14 +4,9 @@ from __future__ import unicode_literals
 import os
 import logging
 import unittest
-
-try:
-    import compare_locales
-except ImportError:
-    compare_locales = None
+import compare_locales
 
 import fluent.syntax.ast as FTL
-
 from fluent.migrate.errors import (
     EmptyLocalizationError, NotSupportedError, UnreadableReferenceError)
 from fluent.migrate.util import ftl, ftl_resource_to_json, to_json
@@ -24,7 +19,6 @@ def here(*parts):
     return os.path.join(dirname, *parts)
 
 
-@unittest.skipUnless(compare_locales, 'compare-locales requried')
 class TestMergeContext(unittest.TestCase):
     def setUp(self):
         self.ctx = MergeContext(
@@ -250,7 +244,6 @@ class TestIncompleteReference(unittest.TestCase):
             self.ctx.add_transforms('some.ftl', 'missing.ftl', [])
 
 
-@unittest.skipUnless(compare_locales, 'compare-locales requried')
 class TestMissingLocalizationFiles(unittest.TestCase):
     def setUp(self):
         # Silence all logging.
@@ -313,7 +306,6 @@ class TestMissingLocalizationFiles(unittest.TestCase):
             ])
 
 
-@unittest.skipUnless(compare_locales, 'compare-locales requried')
 class TestMissingLocalizationStrings(unittest.TestCase):
     maxDiff = None
 
@@ -528,7 +520,6 @@ class TestMissingLocalizationStrings(unittest.TestCase):
         )
 
 
-@unittest.skipUnless(compare_locales, 'compare-locales requried')
 class TestExistingTarget(unittest.TestCase):
     maxDiff = None
 

--- a/tests/migrate/test_context_real_examples.py
+++ b/tests/migrate/test_context_real_examples.py
@@ -3,14 +3,9 @@ from __future__ import unicode_literals
 
 import os
 import unittest
-
-try:
-    import compare_locales
-except ImportError:
-    compare_locales = None
+import compare_locales
 
 import fluent.syntax.ast as FTL
-
 from fluent.migrate.util import ftl_resource_to_json, to_json
 from fluent.migrate.context import MergeContext
 from fluent.migrate.helpers import EXTERNAL_ARGUMENT, MESSAGE_REFERENCE
@@ -24,7 +19,6 @@ def here(*parts):
     return os.path.join(dirname, *parts)
 
 
-@unittest.skipUnless(compare_locales, 'compare-locales requried')
 class TestMergeAboutDownloads(unittest.TestCase):
     def setUp(self):
         self.ctx = MergeContext(
@@ -279,7 +273,6 @@ class TestMergeAboutDownloads(unittest.TestCase):
         )
 
 
-@unittest.skipUnless(compare_locales, 'compare-locales requried')
 class TestMergeAboutDialog(unittest.TestCase):
     maxDiff = None
 

--- a/tests/migrate/test_copy.py
+++ b/tests/migrate/test_copy.py
@@ -2,13 +2,9 @@
 from __future__ import unicode_literals
 
 import unittest
+from compare_locales.parser import PropertiesParser, DTDParser
 
 import fluent.syntax.ast as FTL
-try:
-    from compare_locales.parser import PropertiesParser, DTDParser
-except ImportError:
-    PropertiesParser = DTDParser = None
-
 from fluent.migrate.util import parse, ftl_message_to_json
 from fluent.migrate.transforms import evaluate, COPY
 
@@ -20,7 +16,6 @@ class MockContext(unittest.TestCase):
         return self.strings.get(key, None).val
 
 
-@unittest.skipUnless(PropertiesParser, 'compare-locales required')
 class TestCopy(MockContext):
     def setUp(self):
         self.strings = parse(PropertiesParser, '''
@@ -71,7 +66,6 @@ class TestCopy(MockContext):
         )
 
 
-@unittest.skipUnless(DTDParser, 'compare-locales required')
 class TestCopyAttributes(MockContext):
     def setUp(self):
         self.strings = parse(DTDParser, '''

--- a/tests/migrate/test_merge.py
+++ b/tests/migrate/test_merge.py
@@ -2,14 +2,10 @@
 from __future__ import unicode_literals
 
 import unittest
+from compare_locales.parser import PropertiesParser, DTDParser
 
 import fluent.syntax.ast as FTL
 from fluent.syntax.parser import FluentParser
-try:
-    from compare_locales.parser import PropertiesParser, DTDParser
-except ImportError:
-    PropertiesParser = DTDParser = None
-
 from fluent.migrate.util import parse, ftl, ftl_resource_to_json
 from fluent.migrate.merge import merge_resource
 from fluent.migrate.transforms import COPY
@@ -25,8 +21,6 @@ class MockContext(unittest.TestCase):
             return translation.val
 
 
-@unittest.skipUnless(PropertiesParser and DTDParser,
-                     'compare-locales required')
 class TestMergeMessages(MockContext):
     maxDiff = None
 
@@ -129,8 +123,6 @@ class TestMergeMessages(MockContext):
         )
 
 
-@unittest.skipUnless(PropertiesParser and DTDParser,
-                     'compare-locales required')
 class TestMergeAllEntries(MockContext):
     def setUp(self):
         self.en_us_ftl = parse(FluentParser, ftl('''
@@ -245,8 +237,6 @@ class TestMergeAllEntries(MockContext):
         )
 
 
-@unittest.skipUnless(PropertiesParser and DTDParser,
-                     'compare-locales required')
 class TestMergeSubset(MockContext):
     def setUp(self):
         self.en_us_ftl = parse(FluentParser, ftl('''

--- a/tests/migrate/test_plural.py
+++ b/tests/migrate/test_plural.py
@@ -2,13 +2,9 @@
 from __future__ import unicode_literals
 
 import unittest
+from compare_locales.parser import PropertiesParser
 
 import fluent.syntax.ast as FTL
-try:
-    from compare_locales.parser import PropertiesParser
-except ImportError:
-    PropertiesParser = None
-
 from fluent.migrate.util import parse, ftl_message_to_json
 from fluent.migrate.helpers import EXTERNAL_ARGUMENT
 from fluent.migrate.transforms import evaluate, PLURALS, REPLACE_IN_TEXT
@@ -25,7 +21,6 @@ class MockContext(unittest.TestCase):
         return self.strings.get(key, None).val
 
 
-@unittest.skipUnless(PropertiesParser, 'compare-locales required')
 class TestPlural(MockContext):
     def setUp(self):
         self.strings = parse(PropertiesParser, '''
@@ -79,7 +74,6 @@ class TestPlural(MockContext):
         )
 
 
-@unittest.skipUnless(PropertiesParser, 'compare-locales required')
 class TestPluralLiteral(MockContext):
     def setUp(self):
         self.strings = parse(PropertiesParser, '''
@@ -108,7 +102,6 @@ class TestPluralLiteral(MockContext):
         )
 
 
-@unittest.skipUnless(PropertiesParser, 'compare-locales required')
 class TestPluralReplace(MockContext):
     def setUp(self):
         self.strings = parse(PropertiesParser, '''
@@ -143,7 +136,6 @@ class TestPluralReplace(MockContext):
         )
 
 
-@unittest.skipUnless(PropertiesParser, 'compare-locales required')
 class TestOneCategory(MockContext):
     # Plural categories corresponding to Turkish (tr).
     plural_categories = ('other',)
@@ -177,7 +169,6 @@ class TestOneCategory(MockContext):
         )
 
 
-@unittest.skipUnless(PropertiesParser, 'compare-locales required')
 class TestManyCategories(MockContext):
     # Plural categories corresponding to Polish (pl).
     plural_categories = ('one', 'few', 'many', 'other')

--- a/tests/migrate/test_replace.py
+++ b/tests/migrate/test_replace.py
@@ -2,13 +2,9 @@
 from __future__ import unicode_literals
 
 import unittest
+from compare_locales.parser import PropertiesParser
 
 import fluent.syntax.ast as FTL
-try:
-    from compare_locales.parser import PropertiesParser
-except ImportError:
-    PropertiesParser = None
-
 from fluent.migrate.util import parse, ftl_message_to_json
 from fluent.migrate.helpers import EXTERNAL_ARGUMENT
 from fluent.migrate.transforms import evaluate, REPLACE
@@ -23,7 +19,6 @@ class MockContext(unittest.TestCase):
         return self.strings.get(key, None).val
 
 
-@unittest.skipUnless(PropertiesParser, 'compare-locales required')
 class TestReplace(MockContext):
     def setUp(self):
         self.strings = parse(PropertiesParser, '''

--- a/tests/migrate/test_source.py
+++ b/tests/migrate/test_source.py
@@ -2,14 +2,9 @@
 from __future__ import unicode_literals
 
 import unittest
-
-try:
-    from compare_locales.parser import PropertiesParser, DTDParser
-except ImportError:
-    PropertiesParser = DTDParser = None
+from compare_locales.parser import PropertiesParser, DTDParser
 
 import fluent.syntax.ast as FTL
-
 from fluent.migrate.errors import NotSupportedError
 from fluent.migrate.transforms import Source, COPY, PLURALS, REPLACE
 from fluent.migrate.util import parse
@@ -63,7 +58,6 @@ class MockContext(unittest.TestCase):
         return self.strings[key].val
 
 
-@unittest.skipUnless(PropertiesParser, 'compare-locales required')
 class TestProperties(MockContext):
     def setUp(self):
         self.strings = parse(PropertiesParser, '''
@@ -97,7 +91,6 @@ class TestProperties(MockContext):
         self.assertEqual(source(self), '&lt;&#x21E7;&#x2318;K&gt;')
 
 
-@unittest.skipUnless(DTDParser, 'compare-locales required')
 class TestDTD(MockContext):
     def setUp(self):
         self.strings = parse(DTDParser, '''

--- a/tox.ini
+++ b/tox.ini
@@ -5,8 +5,13 @@ skipsdist=True
 [testenv]
 setenv =
     PYTHONPATH = {toxinidir}
+deps = six
+commands = python -m unittest discover -s tests/syntax
+
+[testenv:py27-cl]
 deps =
     six
-    cl: compare-locales
-
-commands=python -m unittest discover
+    compare-locales
+commands =
+    python -m unittest discover -s tests/syntax
+    python -m unittest discover -s tests/migrate


### PR DESCRIPTION
Make compare-locales a hard requirement for running and testing fluent.migrate which already largely depends on it anyways. This reduces the complexity of imports as well as the burden of deciding if a TestCase depends on compare-locales or not. It also makes it less probable to accidentally skip migration tests with `python -m unittest discover`.

The following commands may be used to run tests:

  - `python setup.py test` - Only syntax tests in tests/syntax will be run. compare-locales is not required.

  - `python -m unittest discover` - All tests will be run. If compare-locales is missing, tests will error.

    It's possible to run only syntax or only migrate tests by specifying the starting director on the CLI:

        python -m unittest discover -s tests/syntax
        python -m unittest discover -s tests/migrate

  - `tox` - Tox will create different envs one if which is py27-cl. It contains compare-locales and is configured to run both tests/syntax and tests/migrate tests. All other tests only run tests/syntax.