### PR TITLE
 PLURALS should be aware of Gecko ordering of variants

### DIFF
--- a/fluent/migrate/cldr.py
+++ b/fluent/migrate/cldr.py
@@ -2,6 +2,7 @@
 
 import pkgutil
 import json
+from compare_locales.plurals import CATEGORIES_BY_LOCALE
 
 
 def in_canonical_order(item):
@@ -53,3 +54,9 @@ def get_plural_categories(lang):
         return get_plural_categories(fallback_lang)
 
     return langs_categories
+
+
+def get_gecko_plural_categories(lang):
+    fallback = ('one', 'other')
+
+    return CATEGORIES_BY_LOCALE.get(lang, fallback)

--- a/fluent/migrate/cldr_data/README.md
+++ b/fluent/migrate/cldr_data/README.md
@@ -1,0 +1,9 @@
+# CLDR Plural Rules
+
+The collection of [language plural rules][1] as defined by CLDR.
+
+To update, copy `supplemental/plurals.json` from the [upstream CLDR
+repository][2] into this directory.
+
+[1]: https://www.unicode.org/cldr/charts/latest/supplemental/language_plural_rules.html
+[2]: https://github.com/unicode-cldr/cldr-core/blob/master/supplemental/plurals.json

--- a/fluent/migrate/cldr_data/plurals.json
+++ b/fluent/migrate/cldr_data/plurals.json
@@ -1,9 +1,9 @@
 {
   "supplemental": {
     "version": {
-      "_number": "$Revision: 12805 $",
-      "_unicodeVersion": "9.0.0",
-      "_cldrVersion": "30"
+      "_number": "$Revision: 13640 $",
+      "_unicodeVersion": "10.0.0",
+      "_cldrVersion": "32.0.1"
     },
     "plurals-type-cardinal": {
       "af": {
@@ -298,6 +298,10 @@
       "in": {
         "pluralRule-count-other": " @integer 0~15, 100, 1000, 10000, 100000, 1000000, … @decimal 0.0~1.5, 10.0, 100.0, 1000.0, 10000.0, 100000.0, 1000000.0, …"
       },
+      "io": {
+        "pluralRule-count-one": "i = 1 and v = 0 @integer 1",
+        "pluralRule-count-other": " @integer 0, 2~16, 100, 1000, 10000, 100000, 1000000, … @decimal 0.0~1.5, 10.0, 100.0, 1000.0, 10000.0, 100000.0, 1000000.0, …"
+      },
       "is": {
         "pluralRule-count-one": "t = 0 and i % 10 = 1 and i % 100 != 11 or t != 0 @integer 1, 21, 31, 41, 51, 61, 71, 81, 101, 1001, … @decimal 0.1~1.6, 10.1, 100.1, 1000.1, …",
         "pluralRule-count-other": " @integer 0, 2~16, 100, 1000, 10000, 100000, 1000000, … @decimal 0.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 10.0, 100.0, 1000.0, 10000.0, 100000.0, 1000000.0, …"
@@ -582,11 +586,11 @@
         "pluralRule-count-other": " @integer 0, 2~16, 100, 1000, 10000, 100000, 1000000, … @decimal 0.0~0.9, 1.1~1.6, 10.0, 100.0, 1000.0, 10000.0, 100000.0, 1000000.0, …"
       },
       "pt": {
-        "pluralRule-count-one": "n = 0..2 and n != 2 @integer 0, 1 @decimal 0.0, 1.0, 0.00, 1.00, 0.000, 1.000, 0.0000, 1.0000",
-        "pluralRule-count-other": " @integer 2~17, 100, 1000, 10000, 100000, 1000000, … @decimal 0.1~0.9, 1.1~1.7, 10.0, 100.0, 1000.0, 10000.0, 100000.0, 1000000.0, …"
+        "pluralRule-count-one": "i = 0..1 @integer 0, 1 @decimal 0.0~1.5",
+        "pluralRule-count-other": " @integer 2~17, 100, 1000, 10000, 100000, 1000000, … @decimal 2.0~3.5, 10.0, 100.0, 1000.0, 10000.0, 100000.0, 1000000.0, …"
       },
       "pt-PT": {
-        "pluralRule-count-one": "n = 1 and v = 0 @integer 1",
+        "pluralRule-count-one": "i = 1 and v = 0 @integer 1",
         "pluralRule-count-other": " @integer 0, 2~16, 100, 1000, 10000, 100000, 1000000, … @decimal 0.0~1.5, 10.0, 100.0, 1000.0, 10000.0, 100000.0, 1000000.0, …"
       },
       "rm": {
@@ -619,6 +623,10 @@
         "pluralRule-count-other": " @integer 0~15, 100, 1000, 10000, 100000, 1000000, … @decimal 0.0~1.5, 10.0, 100.0, 1000.0, 10000.0, 100000.0, 1000000.0, …"
       },
       "saq": {
+        "pluralRule-count-one": "n = 1 @integer 1 @decimal 1.0, 1.00, 1.000, 1.0000",
+        "pluralRule-count-other": " @integer 0, 2~16, 100, 1000, 10000, 100000, 1000000, … @decimal 0.0~0.9, 1.1~1.6, 10.0, 100.0, 1000.0, 10000.0, 100000.0, 1000000.0, …"
+      },
+      "sd": {
         "pluralRule-count-one": "n = 1 @integer 1 @decimal 1.0, 1.00, 1.000, 1.0000",
         "pluralRule-count-other": " @integer 0, 2~16, 100, 1000, 10000, 100000, 1000000, … @decimal 0.0~0.9, 1.1~1.6, 10.0, 100.0, 1000.0, 10000.0, 100000.0, 1000000.0, …"
       },

--- a/tests/migrate/test_plural.py
+++ b/tests/migrate/test_plural.py
@@ -74,6 +74,39 @@ class TestPlural(MockContext):
         )
 
 
+class TestPluralOrder(MockContext):
+    # Plural categories corresponding to Lithuanian (lt).
+    plural_categories = ('one', 'few', 'other')
+
+    def setUp(self):
+        self.strings = parse(PropertiesParser, '''
+            # These forms correspond to (one, other, few) in CLDR
+            deleteAll = Pašalinti #1 atsiuntimą?;Pašalinti #1 atsiuntimų?;Pašalinti #1 atsiuntimus?
+        ''')
+
+        self.message = FTL.Message(
+            FTL.Identifier('delete-all'),
+            value=PLURALS(
+                'test.properties',
+                'deleteAll',
+                EXTERNAL_ARGUMENT('num')
+            )
+        )
+
+    def test_plural(self):
+        self.assertEqual(
+            evaluate(self, self.message).to_json(),
+            ftl_message_to_json('''
+                delete-all =
+                    { $num ->
+                        [one] Pašalinti #1 atsiuntimą?
+                        [few] Pašalinti #1 atsiuntimus?
+                       *[other] Pašalinti #1 atsiuntimų?
+                    }
+            ''')
+        )
+
+
 class TestPluralLiteral(MockContext):
     def setUp(self):
         self.strings = parse(PropertiesParser, '''


### PR DESCRIPTION
WIP for https://bugzilla.mozilla.org/show_bug.cgi?id=1415844.

The goal of this bug is the change the migration code such that when a string like downloadMessage.deleteAll is migrated to Fluent in Lithuanian, the first part of the legacy string is assigned to the [one] variant, the second part is assigned to the [other] variant, and the third part is assigned to the [few] variant.

Additionally, we should make sure we choose the default variant well. Right now, the last form as defined in .properties is used as the default. Instead, I suggest that we use 'other' and if it doesn't exist, we use 'many'. According to https://hg.mozilla.org/l10n/compare-locales/file/tip/compare_locales/plurals.py all Gecko plural forms have at least one of these categories.