### PR TITLE
Compare Terms and Messages in migrations, fixes bug 1437833

### DIFF
--- a/fluent/migrate/context.py
+++ b/fluent/migrate/context.py
@@ -254,9 +254,10 @@ class MergeContext(object):
         return resource.get(key, None)
 
     def messages_equal(self, res1, res2):
-        """Compare messages of two FTL resources.
+        """Compare messages and terms of two FTL resources.
 
-        Uses FTL.BaseNode.equals to compare all messages in two FTL resources.
+        Uses FTL.BaseNode.equals to compare all messages/terms
+        in two FTL resources.
         If the order or number of messages differ, the result is also False.
         """
         def message_id(message):
@@ -264,10 +265,14 @@ class MergeContext(object):
             return message.id.name
 
         messages1 = sorted(
-            (entry for entry in res1.body if isinstance(entry, FTL.Message)),
+            (entry for entry in res1.body
+             if isinstance(entry, FTL.Message)
+                or isinstance(entry, FTL.Term)),
             key=message_id)
         messages2 = sorted(
-            (entry for entry in res2.body if isinstance(entry, FTL.Message)),
+            (entry for entry in res2.body
+             if isinstance(entry, FTL.Message)
+                or isinstance(entry, FTL.Term)),
             key=message_id)
         for msg1, msg2 in zip_longest(messages1, messages2):
             if msg1 is None or msg2 is None:

--- a/tests/migrate/test_context.py
+++ b/tests/migrate/test_context.py
@@ -659,3 +659,132 @@ class TestNotSupportedError(unittest.TestCase):
             )
 
             ctx.maybe_add_localization('privacy.ftl')
+
+
+class TestMessagesEqual(unittest.TestCase):
+    maxDiff = None
+
+    def setUp(self):
+        # Silence all logging.
+        logging.disable(logging.CRITICAL)
+
+        self.ctx = MergeContext(
+            lang='pl',
+            reference_dir=here('fixtures/en-US'),
+            localization_dir=here('fixtures/pl')
+        )
+
+    def tearDown(self):
+        # Resume logging.
+        logging.disable(logging.NOTSET)
+
+    def test_messages_equal(self):
+        first = FTL.Resource([
+            FTL.Message(
+                id=FTL.Identifier('bar'),
+                value=FTL.Pattern([
+                    FTL.TextElement('Hardcoded Value')
+                ])
+            ),
+        ])
+        second = FTL.Resource([
+            FTL.Message(
+                id=FTL.Identifier('bar'),
+                value=FTL.Pattern([
+                    FTL.TextElement('Hardcoded Value')
+                ])
+            ),
+        ])
+        self.assertTrue(self.ctx.messages_equal(first, second))
+
+    def test_messages_different_attributes(self):
+        first = FTL.Resource([
+            FTL.Message(
+                id=FTL.Identifier('bar'),
+                value=FTL.Pattern([
+                    FTL.TextElement('Hardcoded Value')
+                ])
+            ),
+        ])
+        second = FTL.Resource([
+            FTL.Message(
+                id=FTL.Identifier('bar'),
+                value=FTL.Pattern([
+                    FTL.TextElement('Hardcoded Value')
+                ]),
+                attributes=[
+                    FTL.Attribute(
+                        FTL.Identifier('one'),
+                        value=FTL.Pattern([
+                            FTL.TextElement('Attribute Value')
+                        ])
+                    ),
+                ]
+            ),
+        ])
+        self.assertFalse(self.ctx.messages_equal(first, second))
+
+    def test_terms_equal(self):
+        first = FTL.Resource([
+            FTL.Term(
+                id=FTL.Identifier('-bar'),
+                value=FTL.Pattern([
+                    FTL.TextElement('Hardcoded Value')
+                ])
+            ),
+        ])
+        second = FTL.Resource([
+            FTL.Term(
+                id=FTL.Identifier('-bar'),
+                value=FTL.Pattern([
+                    FTL.TextElement('Hardcoded Value')
+                ])
+            ),
+        ])
+        self.assertTrue(self.ctx.messages_equal(first, second))
+
+    def test_terms_different_attributes(self):
+        first = FTL.Resource([
+            FTL.Term(
+                id=FTL.Identifier('-bar'),
+                value=FTL.Pattern([
+                    FTL.TextElement('Hardcoded Value')
+                ])
+            ),
+        ])
+        second = FTL.Resource([
+            FTL.Term(
+                id=FTL.Identifier('-bar'),
+                value=FTL.Pattern([
+                    FTL.TextElement('Hardcoded Value')
+                ]),
+                attributes=[
+                    FTL.Attribute(
+                        FTL.Identifier('one'),
+                        value=FTL.Pattern([
+                            FTL.TextElement('Attribute Value')
+                        ])
+                    ),
+                ]
+            ),
+        ])
+        self.assertFalse(self.ctx.messages_equal(first, second))
+
+    def test_term_and_message(self):
+        first = FTL.Resource([
+            FTL.Term(
+                id=FTL.Identifier('-bar'),
+                value=FTL.Pattern([
+                    FTL.TextElement('Hardcoded Value')
+                ])
+            ),
+        ])
+        second = FTL.Resource([
+            FTL.Message(
+                id=FTL.Identifier('bar'),
+                value=FTL.Pattern([
+                    FTL.TextElement('Hardcoded Value')
+                ])
+            ),
+        ])
+        self.assertFalse(self.ctx.messages_equal(first, second))


### PR DESCRIPTION
When adding Terms, we didn't add them to the list of entries
to compare in MergeContext.messages_equal. When migrating
to fluent files where only Terms differ from changeset to changeset,
that lead to no migration being created for that changeset.