### PR TITLE
bug 1438570, roll up known translation and apply transform when last …

### DIFF
--- a/fluent/migrate/context.py
+++ b/fluent/migrate/context.py
@@ -281,7 +281,7 @@ class MergeContext(object):
                 return False
         return True
 
-    def merge_changeset(self, changeset=None):
+    def merge_changeset(self, changeset=None, known_translations=None):
         """Return a generator of FTL ASTs for the changeset.
 
         The input data must be configured earlier using the `add_*` methods.
@@ -309,6 +309,9 @@ class MergeContext(object):
                 if not path.endswith('.ftl')
                 for key in strings.iterkeys()
             }
+
+        if known_translations is None:
+            known_translations = changeset
 
         for path, reference in self.reference_resources.iteritems():
             current = self.localization_resources[path]
@@ -344,8 +347,11 @@ class MergeContext(object):
                 # Make sure all the dependencies are present in the current
                 # changeset. Partial migrations are not currently supported.
                 # See https://bugzilla.mozilla.org/show_bug.cgi?id=1321271
-                available_deps = message_deps & changeset
-                return message_deps == available_deps
+                # We only return True if our current changeset touches
+                # the transform, and we have all of the dependencies.
+                active_deps = message_deps & changeset
+                available_deps = message_deps & known_translations
+                return active_deps and message_deps == available_deps
 
             # Merge legacy translations with the existing ones using the
             # reference as a template.
@@ -370,7 +376,7 @@ class MergeContext(object):
             # The result for this path is a complete `FTL.Resource`.
             yield path, snapshot
 
-    def serialize_changeset(self, changeset):
+    def serialize_changeset(self, changeset, known_translations=None):
         """Return a dict of serialized FTLs for the changeset.
 
         Given `changeset`, return a dict whose keys are resource paths and
@@ -379,7 +385,9 @@ class MergeContext(object):
 
         return {
             path: self.fluent_serializer.serialize(snapshot)
-            for path, snapshot in self.merge_changeset(changeset)
+            for path, snapshot in self.merge_changeset(
+                changeset, known_translations
+            )
         }
 
 

--- a/tools/migrate/migrate-l10n.py
+++ b/tools/migrate/migrate-l10n.py
@@ -47,10 +47,17 @@ def main(lang, reference_dir, localization_dir, migrations, dry_run):
             if not path.endswith('.ftl'))
         blame = Blame(client).attribution(files)
         changesets = convert_blame_to_changesets(blame)
+        known_legacy_translations = set()
 
         for changeset in changesets:
-            # Run the migration for the changeset.
-            snapshot = ctx.serialize_changeset(changeset['changes'])
+            changes_in_changeset = changeset['changes']
+            known_legacy_translations.update(changes_in_changeset)
+            # Run the migration for the changeset, with the set of
+            # this and all prior legacy translations.
+            snapshot = ctx.serialize_changeset(
+                changes_in_changeset,
+                known_legacy_translations
+            )
 
             # Did it change any files?
             if not snapshot:


### PR DESCRIPTION
…dependency trickles in

If the dependencies of a transform come in different changesets,
we need to wait until they're all there.
Only if we don't find them all throughout all our changesets, we
shouldn't transform at all.
We can't start with intermediate transforms, 'cause that'd require
that we can do partial transforms, which is still bug 1321271.

Instead of just aggregating changeset.changes, keep track of
all our existing legacy strings in an extra set. That way,
we only transform files and messages touched by this very string.
That's a performance optimization. If we just went for it and
aggregated the changes and passed them to serialize_changeset,
we'd transform each file we touched before, found the snapshot
didn't change and ignore it. Keeping both datasets separate just
makes this quicker.