### PR TITLE
Bug 1441799 - Support number variant keys in BaseNode.equals

### DIFF
--- a/tests/syntax/test_equals.py
+++ b/tests/syntax/test_equals.py
@@ -119,6 +119,25 @@ class TestOrderEquals(unittest.TestCase):
         self.assertTrue(message1.equals(message2))
         self.assertTrue(message2.equals(message1))
 
+    def test_variants_with_numbers(self):
+        message1 = self.parse_ftl_entry("""\
+            foo =
+                { $num ->
+                    [1] A
+                   *[b] B
+                }
+        """)
+        message2 = self.parse_ftl_entry("""\
+            foo =
+                { $num ->
+                   *[b] B
+                    [1] A
+                }
+        """)
+
+        self.assertTrue(message1.equals(message2))
+        self.assertTrue(message2.equals(message1))
+
 
 class TestEqualWithSpans(unittest.TestCase):
     def test_default_behavior(self):


### PR DESCRIPTION
`BaseNode.equals` sorts order-agnostic fields such as attributes and variants in order to ensure the equality comparison works correctly even if the order of the elements differs. The code used to assume all variant keys were `VariantName` instances. We need to support numbers as keys as well.

See https://bugzilla.mozilla.org/show_bug.cgi?id=1441799.