### PR TITLE
Migrate empty translations

### DIFF
--- a/tests/migrate/test_concat.py
+++ b/tests/migrate/test_concat.py
@@ -5,8 +5,6 @@ import unittest
 from compare_locales.parser import PropertiesParser, DTDParser
 
 import fluent.syntax.ast as FTL
-from fluent.util import ftl
-from fluent.syntax.serializer import FluentSerializer
 from fluent.migrate.util import parse, ftl_message_to_json
 from fluent.migrate.helpers import EXTERNAL_ARGUMENT, MESSAGE_REFERENCE
 from fluent.migrate.transforms import evaluate, CONCAT, COPY, REPLACE
@@ -19,10 +17,6 @@ class MockContext(unittest.TestCase):
         # Ignore path (test.properties) and get translations from self.strings
         # defined in setUp.
         return self.strings.get(key, None).val
-
-    def serialize_entry(self, entry):
-        serializer = FluentSerializer()
-        return serializer.serialize_entry(entry)
 
 
 class TestConcatCopy(MockContext):
@@ -118,9 +112,6 @@ class TestConcatCopy(MockContext):
             ''')
         )
 
-    # XXX Encode leading whitespace as {""}
-    # See https://bugzilla.mozilla.org/show_bug.cgi?id=1374246
-    # See https://bugzilla.mozilla.org/show_bug.cgi?id=1397233
     def test_concat_whitespace_begin(self):
         msg = FTL.Message(
             FTL.Identifier('hello'),
@@ -130,34 +121,13 @@ class TestConcatCopy(MockContext):
             )
         )
 
-        message = evaluate(self, msg)
-
         self.assertEqual(
-            len(message.value.elements), 1,
-            'The constructed value should have only one element'
-        )
-
-        text, = message.value.elements
-
-        self.assertIsInstance(
-            text, FTL.TextElement,
-            'The constructed element should be a TextElement.'
-        )
-        self.assertEqual(
-            text.value, ' Hello, world!',
-            'The TextElement should be a concatenation of the sources.'
-        )
-
-        self.assertEqual(
-            self.serialize_entry(message),
-            ftl('''
-                hello =  Hello, world!
+            evaluate(self, msg).to_json(),
+            ftl_message_to_json('''
+                hello = {" "}Hello, world!
             ''')
         )
 
-    # XXX Encode trailing whitespace as {""}
-    # See https://bugzilla.mozilla.org/show_bug.cgi?id=1374246
-    # See https://bugzilla.mozilla.org/show_bug.cgi?id=1397233
     def test_concat_whitespace_end(self):
         msg = FTL.Message(
             FTL.Identifier('hello'),
@@ -167,28 +137,10 @@ class TestConcatCopy(MockContext):
             )
         )
 
-        message = evaluate(self, msg)
-
         self.assertEqual(
-            len(message.value.elements), 1,
-            'The constructed value should have only one element'
-        )
-
-        text, = message.value.elements
-
-        self.assertIsInstance(
-            text, FTL.TextElement,
-            'The constructed element should be a TextElement.'
-        )
-        self.assertEqual(
-            text.value, 'Hello, world! ',
-            'The TextElement should be a concatenation of the sources.'
-        )
-
-        self.assertEqual(
-            self.serialize_entry(message),
-            ftl('''
-                hello = Hello, world! 
+            evaluate(self, msg).to_json(),
+            ftl_message_to_json('''
+                hello = Hello, world!{" "}
             ''')
         )
 

--- a/tests/migrate/test_concat.py
+++ b/tests/migrate/test_concat.py
@@ -5,6 +5,8 @@ import unittest
 from compare_locales.parser import PropertiesParser, DTDParser
 
 import fluent.syntax.ast as FTL
+from fluent.util import ftl
+from fluent.syntax.serializer import FluentSerializer
 from fluent.migrate.util import parse, ftl_message_to_json
 from fluent.migrate.helpers import EXTERNAL_ARGUMENT, MESSAGE_REFERENCE
 from fluent.migrate.transforms import evaluate, CONCAT, COPY, REPLACE
@@ -18,6 +20,10 @@ class MockContext(unittest.TestCase):
         # defined in setUp.
         return self.strings.get(key, None).val
 
+    def serialize_entry(self, entry):
+        serializer = FluentSerializer()
+        return serializer.serialize_entry(entry)
+
 
 class TestConcatCopy(MockContext):
     def setUp(self):
@@ -25,6 +31,9 @@ class TestConcatCopy(MockContext):
             hello = Hello, world!
             hello.start = Hello,\\u0020
             hello.end = world!
+            empty =
+            empty.start =
+            empty.end =
             whitespace.begin.start = \\u0020Hello,\\u0020
             whitespace.begin.end = world!
             whitespace.end.start = Hello,\\u0020
@@ -55,32 +64,63 @@ class TestConcatCopy(MockContext):
             )
         )
 
-        result = evaluate(self, msg)
-
         self.assertEqual(
-            len(result.value.elements),
-            1,
-            'The constructed value should have only one element'
-        )
-        self.assertIsInstance(
-            result.value.elements[0],
-            FTL.TextElement,
-            'The constructed element should be a TextElement.'
-        )
-        self.assertEqual(
-            result.value.elements[0].value,
-            'Hello, world!',
-            'The TextElement should be a concatenation of the sources.'
-        )
-
-        self.assertEqual(
-            result.to_json(),
+            evaluate(self, msg).to_json(),
             ftl_message_to_json('''
                 hello = Hello, world!
             ''')
         )
 
-    @unittest.skip('Parser/Serializer trim whitespace')
+    def test_concat_empty_one(self):
+        msg = FTL.Message(
+            FTL.Identifier('empty'),
+            value=CONCAT(
+                COPY('test.properties', 'empty'),
+            )
+        )
+
+        self.assertEqual(
+            evaluate(self, msg).to_json(),
+            ftl_message_to_json('''
+                empty = {""}
+            ''')
+        )
+
+    def test_concat_empty_two(self):
+        msg = FTL.Message(
+            FTL.Identifier('empty'),
+            value=CONCAT(
+                COPY('test.properties', 'empty.start'),
+                COPY('test.properties', 'empty.end'),
+            )
+        )
+
+        self.assertEqual(
+            evaluate(self, msg).to_json(),
+            ftl_message_to_json('''
+                empty = {""}
+            ''')
+        )
+
+    def test_concat_nonempty_empty(self):
+        msg = FTL.Message(
+            FTL.Identifier('combined'),
+            value=CONCAT(
+                COPY('test.properties', 'hello'),
+                COPY('test.properties', 'empty'),
+            )
+        )
+
+        self.assertEqual(
+            evaluate(self, msg).to_json(),
+            ftl_message_to_json('''
+                combined = Hello, world!
+            ''')
+        )
+
+    # XXX Encode leading whitespace as {""}
+    # See https://bugzilla.mozilla.org/show_bug.cgi?id=1374246
+    # See https://bugzilla.mozilla.org/show_bug.cgi?id=1397233
     def test_concat_whitespace_begin(self):
         msg = FTL.Message(
             FTL.Identifier('hello'),
@@ -90,14 +130,34 @@ class TestConcatCopy(MockContext):
             )
         )
 
+        message = evaluate(self, msg)
+
         self.assertEqual(
-            evaluate(self, msg).to_json(),
-            ftl_message_to_json('''
-                hello = {" "}Hello, world!
+            len(message.value.elements), 1,
+            'The constructed value should have only one element'
+        )
+
+        text, = message.value.elements
+
+        self.assertIsInstance(
+            text, FTL.TextElement,
+            'The constructed element should be a TextElement.'
+        )
+        self.assertEqual(
+            text.value, ' Hello, world!',
+            'The TextElement should be a concatenation of the sources.'
+        )
+
+        self.assertEqual(
+            self.serialize_entry(message),
+            ftl('''
+                hello =  Hello, world!
             ''')
         )
 
-    @unittest.skip('Parser/Serializer trim whitespace')
+    # XXX Encode trailing whitespace as {""}
+    # See https://bugzilla.mozilla.org/show_bug.cgi?id=1374246
+    # See https://bugzilla.mozilla.org/show_bug.cgi?id=1397233
     def test_concat_whitespace_end(self):
         msg = FTL.Message(
             FTL.Identifier('hello'),
@@ -107,10 +167,28 @@ class TestConcatCopy(MockContext):
             )
         )
 
+        message = evaluate(self, msg)
+
         self.assertEqual(
-            evaluate(self, msg).to_json(),
-            ftl_message_to_json('''
-                hello = Hello, world!
+            len(message.value.elements), 1,
+            'The constructed value should have only one element'
+        )
+
+        text, = message.value.elements
+
+        self.assertIsInstance(
+            text, FTL.TextElement,
+            'The constructed element should be a TextElement.'
+        )
+        self.assertEqual(
+            text.value, 'Hello, world! ',
+            'The TextElement should be a concatenation of the sources.'
+        )
+
+        self.assertEqual(
+            self.serialize_entry(message),
+            ftl('''
+                hello = Hello, world! 
             ''')
         )
 

--- a/tests/migrate/test_context_real_examples.py
+++ b/tests/migrate/test_context_real_examples.py
@@ -321,7 +321,7 @@ class TestMergeAboutDialog(unittest.TestCase):
                         'aboutDialog.dtd',
                         'community.mozillaLink',
                         {
-                            '&vendorBrandShortName;': MESSAGE_REFERENCE(
+                            '&vendorShortName;': MESSAGE_REFERENCE(
                                 'vendor-short-name'
                             )
                         }
@@ -336,7 +336,6 @@ class TestMergeAboutDialog(unittest.TestCase):
             ),
         ])
 
-    @unittest.skip('Parser/Serializer trim whitespace')
     def test_merge_context_all_messages(self):
         expected = {
             'aboutDialog.ftl': ftl_resource_to_json('''
@@ -345,8 +344,8 @@ class TestMergeAboutDialog(unittest.TestCase):
         # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
         update-failed = Aktualizacja się nie powiodła. <a>Pobierz</a>.
-        channel-desc = Obecnie korzystasz z kanału { $channelname }.
-        community = Program { $brand-short-name } został opracowany przez <a>organizację { $vendor-short-name }</a>, która jest <a>globalną społecznością</a>, starającą się zapewnić, by…
+        channel-desc = Obecnie korzystasz z kanału { $channelname }.{" "}
+        community = Program { brand-short-name } został opracowany przez <a>organizację { vendor-short-name }</a>, która jest <a>globalną społecznością</a>, starającą się zapewnić, by…
             ''')
         }
 

--- a/tests/migrate/test_copy.py
+++ b/tests/migrate/test_copy.py
@@ -24,8 +24,10 @@ class TestCopy(MockContext):
             foo = Foo
             empty =
             unicode.all = \\u0020
-            unicode.begin = \\u0020Foo
-            unicode.end = Foo\\u0020
+            unicode.begin1 = \\u0020Foo
+            unicode.begin2 = \\u0020\\u0020Foo
+            unicode.end1 = Foo\\u0020
+            unicode.end2 = Foo\\u0020\\u0020
         ''')
 
     def test_copy(self):
@@ -67,31 +69,55 @@ class TestCopy(MockContext):
             ''')
         )
 
-    @unittest.skip('Parser/Serializer trim whitespace')
     def test_copy_escape_unicode_begin(self):
         msg = FTL.Message(
             FTL.Identifier('unicode-begin'),
-            value=COPY('test.properties', 'unicode.begin')
+            value=COPY('test.properties', 'unicode.begin1')
         )
 
         self.assertEqual(
             evaluate(self, msg).to_json(),
             ftl_message_to_json('''
-                unicode-begin = Foo
+                unicode-begin = {" "}Foo
             ''')
         )
 
-    @unittest.skip('Parser/Serializer trim whitespace')
-    def test_copy_escape_unicode_end(self):
+    def test_copy_escape_unicode_begin_many(self):
         msg = FTL.Message(
-            FTL.Identifier('unicode-end'),
-            value=COPY('test.properties', 'unicode.end')
+            FTL.Identifier('unicode-begin'),
+            value=COPY('test.properties', 'unicode.begin2')
         )
 
         self.assertEqual(
             evaluate(self, msg).to_json(),
             ftl_message_to_json('''
-                unicode-end = Foo
+                unicode-begin = {"  "}Foo
+            ''')
+        )
+
+    def test_copy_escape_unicode_end(self):
+        msg = FTL.Message(
+            FTL.Identifier('unicode-end'),
+            value=COPY('test.properties', 'unicode.end1')
+        )
+
+        self.assertEqual(
+            evaluate(self, msg).to_json(),
+            ftl_message_to_json('''
+                unicode-end = Foo{" "}
+            ''')
+        )
+
+    def test_copy_escape_unicode_end_many(self):
+        msg = FTL.Message(
+            FTL.Identifier('unicode-end'),
+            value=COPY('test.properties', 'unicode.end2')
+        )
+
+        self.assertEqual(
+            evaluate(self, msg).to_json(),
+            ftl_message_to_json('''
+                unicode-end = Foo{"  "}
             ''')
         )
 

--- a/tests/migrate/test_plural.py
+++ b/tests/migrate/test_plural.py
@@ -230,7 +230,6 @@ class TestEmpty(MockContext):
             ftl_message_to_json('''
                 plural =
                     { $num ->
-                        [one] {""}
                         [few] Few
                        *[many] Many
                     }
@@ -249,7 +248,7 @@ class TestEmpty(MockContext):
                     { $num ->
                         [one] One
                         [few] Few
-                       *[many] {""}
+                       *[many] Few
                     }
             ''')
         )
@@ -262,12 +261,7 @@ class TestEmpty(MockContext):
         self.assertEqual(
             evaluate(self, self.message).to_json(),
             ftl_message_to_json('''
-                plural =
-                    { $num ->
-                        [one] {""}
-                        [few] {""}
-                       *[many] {""}
-                    }
+                plural = {""}
             ''')
         )
 

--- a/tests/migrate/test_replace.py
+++ b/tests/migrate/test_replace.py
@@ -22,11 +22,31 @@ class MockContext(unittest.TestCase):
 class TestReplace(MockContext):
     def setUp(self):
         self.strings = parse(PropertiesParser, '''
+            empty =
             hello = Hello, #1!
             welcome = Welcome, #1, to #2!
             first = #1 Bar
             last = Foo #1
         ''')
+
+    def test_replace_empty(self):
+        msg = FTL.Message(
+            FTL.Identifier(u'empty'),
+            value=REPLACE(
+                'test.properties',
+                'empty',
+                {
+                    '#1': EXTERNAL_ARGUMENT('arg')
+                }
+            )
+        )
+
+        self.assertEqual(
+            evaluate(self, msg).to_json(),
+            ftl_message_to_json('''
+                empty = {""}
+            ''')
+        )
 
     def test_replace_one(self):
         msg = FTL.Message(

--- a/tests/migrate/test_source.py
+++ b/tests/migrate/test_source.py
@@ -62,7 +62,10 @@ class TestProperties(MockContext):
     def setUp(self):
         self.strings = parse(PropertiesParser, '''
             foo = Foo
+            value-empty =
+            value-whitespace =    
 
+            unicode-all = \\u0020
             unicode-start = \\u0020Foo
             unicode-middle = Foo\\u0020Bar
             unicode-end = Foo\\u0020
@@ -72,29 +75,60 @@ class TestProperties(MockContext):
 
     def test_simple_text(self):
         source = Source('test.properties', 'foo')
-        self.assertEqual(source(self), 'Foo')
+        element = source(self)
+        self.assertIsInstance(element, FTL.TextElement)
+        self.assertEqual(element.value, 'Foo')
+
+    def test_empty_value(self):
+        source = Source('test.properties', 'value-empty')
+        element = source(self)
+        self.assertIsInstance(element, FTL.TextElement)
+        self.assertEqual(element.value, '')
+
+    def test_whitespace_value(self):
+        source = Source('test.properties', 'value-whitespace')
+        element = source(self)
+        self.assertIsInstance(element, FTL.TextElement)
+        self.assertEqual(element.value, '')
+
+    def test_escape_unicode_all(self):
+        source = Source('test.properties', 'unicode-all')
+        element = source(self)
+        self.assertIsInstance(element, FTL.TextElement)
+        self.assertEqual(element.value, ' ')
 
     def test_escape_unicode_start(self):
         source = Source('test.properties', 'unicode-start')
-        self.assertEqual(source(self), ' Foo')
+        element = source(self)
+        self.assertIsInstance(element, FTL.TextElement)
+        self.assertEqual(element.value, ' Foo')
 
     def test_escape_unicode_middle(self):
         source = Source('test.properties', 'unicode-middle')
-        self.assertEqual(source(self), 'Foo Bar')
+        element = source(self)
+        self.assertIsInstance(element, FTL.TextElement)
+        self.assertEqual(element.value, 'Foo Bar')
 
     def test_escape_unicode_end(self):
         source = Source('test.properties', 'unicode-end')
-        self.assertEqual(source(self), 'Foo ')
+        element = source(self)
+        self.assertIsInstance(element, FTL.TextElement)
+        self.assertEqual(element.value, 'Foo ')
 
     def test_html_entity(self):
         source = Source('test.properties', 'html-entity')
-        self.assertEqual(source(self), '&lt;&#x21E7;&#x2318;K&gt;')
+        element = source(self)
+        self.assertIsInstance(element, FTL.TextElement)
+        self.assertEqual(element.value, '&lt;&#x21E7;&#x2318;K&gt;')
 
 
 class TestDTD(MockContext):
     def setUp(self):
         self.strings = parse(DTDParser, '''
             <!ENTITY foo "Foo">
+
+            <!ENTITY valueEmpty "">
+            <!ENTITY valueWhitespace "    ">
 
             <!ENTITY unicodeEscape "Foo\\u0020Bar">
 
@@ -107,28 +141,54 @@ class TestDTD(MockContext):
 
     def test_simple_text(self):
         source = Source('test.dtd', 'foo')
-        self.assertEqual(source(self), 'Foo')
+        element = source(self)
+        self.assertIsInstance(element, FTL.TextElement)
+        self.assertEqual(element.value, 'Foo')
+
+    def test_empty_value(self):
+        source = Source('test.dtd', 'valueEmpty')
+        element = source(self)
+        self.assertIsInstance(element, FTL.TextElement)
+        self.assertEqual(element.value, '')
+
+    def test_whitespace_value(self):
+        source = Source('test.dtd', 'valueWhitespace')
+        element = source(self)
+        self.assertIsInstance(element, FTL.TextElement)
+        self.assertEqual(element.value, '    ')
 
     def test_backslash_unicode_escape(self):
         source = Source('test.dtd', 'unicodeEscape')
-        self.assertEqual(source(self), 'Foo\\u0020Bar')
+        element = source(self)
+        self.assertIsInstance(element, FTL.TextElement)
+        self.assertEqual(element.value, 'Foo\\u0020Bar')
 
     def test_named_entity(self):
         source = Source('test.dtd', 'named')
-        self.assertEqual(source(self), '&')
+        element = source(self)
+        self.assertIsInstance(element, FTL.TextElement)
+        self.assertEqual(element.value, '&')
 
     def test_decimal_entity(self):
         source = Source('test.dtd', 'decimal')
-        self.assertEqual(source(self), '&')
+        element = source(self)
+        self.assertIsInstance(element, FTL.TextElement)
+        self.assertEqual(element.value, '&')
 
     def test_shorthex_entity(self):
         source = Source('test.dtd', 'shorthexcode')
-        self.assertEqual(source(self), '&')
+        element = source(self)
+        self.assertIsInstance(element, FTL.TextElement)
+        self.assertEqual(element.value, '&')
 
     def test_longhex_entity(self):
         source = Source('test.dtd', 'longhexcode')
-        self.assertEqual(source(self), '&')
+        element = source(self)
+        self.assertIsInstance(element, FTL.TextElement)
+        self.assertEqual(element.value, '&')
 
     def test_unknown_entity(self):
         source = Source('test.dtd', 'unknown')
-        self.assertEqual(source(self), '&unknownEntity;')
+        element = source(self)
+        self.assertIsInstance(element, FTL.TextElement)
+        self.assertEqual(element.value, '&unknownEntity;')


### PR DESCRIPTION
Migrate empty translations as {""}. See https://bugzil.la/1441942.

<del>Empty plural variants are also kept as {""} to preserve as much of the original intent as possible. Dropping them could result in different behavior when the default variant is displayed instead.</del>

<del>This doesn't address migrating leading and trailing whitespace in non-whitespace-only legacy translations. See https://bugzil.la/1374246.</del>

<ins>See https://github.com/projectfluent/python-fluent/pull/54#issuecomment-371536006.</ins>