### PR TITLE
bug 1447905, missing dependencies in REPLACE

### DIFF
--- a/fluent/util.py
+++ b/fluent/util.py
@@ -36,6 +36,8 @@ def fold(fun, node, init):
             acc = fold(fun, head, acc)
         if isinstance(head, list):
             acc = fold_(head, acc)
+        if isinstance(head, dict):
+            acc = fold_(head.values(), acc)
 
         return fold_(tail, fun(acc, head))
 

--- a/tests/migrate/test_util.py
+++ b/tests/migrate/test_util.py
@@ -5,7 +5,7 @@ import unittest
 
 import fluent.syntax.ast as FTL
 from fluent.util import fold
-from fluent.migrate.transforms import CONCAT, COPY, Source
+from fluent.migrate.transforms import CONCAT, COPY, REPLACE, Source
 
 
 def get_source(acc, cur):
@@ -80,4 +80,21 @@ class TestReduce(unittest.TestCase):
         self.assertEqual(
             fold(get_source, node, ()),
             (('path1', 'key1'), ('path2', 'key2'))
+        )
+
+    def test_copy_in_replace(self):
+        node = FTL.Message(
+            FTL.Identifier('hello'),
+            value=REPLACE(
+                'path1',
+                'key1',
+                {
+                    "foo": COPY('path2', 'key2')
+                }
+            )
+        )
+
+        self.assertEqual(
+            fold(get_source, node, ()),
+            (('path2', 'key2'), ('path1', 'key1'))
         )


### PR DESCRIPTION
The replacements in a REPLACE transform are in a dict,
which fold() didn't go in to.