### PR TITLE
fixes bug 1451450, parse VariantExpressions with a MessageReference inside

### DIFF
--- a/fluent/syntax/ast.py
+++ b/fluent/syntax/ast.py
@@ -245,9 +245,9 @@ class AttributeExpression(Expression):
 
 
 class VariantExpression(Expression):
-    def __init__(self, id, key, **kwargs):
+    def __init__(self, of, key, **kwargs):
         super(VariantExpression, self).__init__(**kwargs)
-        self.id = id
+        self.of = of
         self.key = key
 
 

--- a/fluent/syntax/parser.py
+++ b/fluent/syntax/parser.py
@@ -518,7 +518,7 @@ class FluentParser(object):
             ps.next()
             key = self.get_variant_key(ps)
             ps.expect_char(']')
-            return ast.VariantExpression(literal.id, key)
+            return ast.VariantExpression(literal, key)
 
         if (ch == '('):
             ps.next()

--- a/fluent/syntax/serializer.py
+++ b/fluent/syntax/serializer.py
@@ -235,7 +235,7 @@ def serialize_attribute_expression(expr):
 
 def serialize_variant_expression(expr):
     return "{}[{}]".format(
-        serialize_identifier(expr.id),
+        serialize_identifier(expr.of.id),
         serialize_variant_key(expr.key),
     )
 

--- a/tests/syntax/fixtures_structure/term.json
+++ b/tests/syntax/fixtures_structure/term.json
@@ -189,9 +189,17 @@
             "type": "Placeable",
             "expression": {
               "type": "VariantExpression",
-              "id": {
-                "type": "Identifier",
-                "name": "-brand-name",
+              "of": {
+                "type": "MessageReference",
+                "id": {
+                  "type": "Identifier",
+                  "name": "-brand-name",
+                  "span": {
+                    "type": "Span",
+                    "start": 145,
+                    "end": 156
+                  }
+                },
                 "span": {
                   "type": "Span",
                   "start": 145,


### PR DESCRIPTION
This switches the props of VariantExpression from having a
string `id` to a `MessageReference` `of`