### PR TITLE
Make fluent.syntax a proper pkgutil-style namespace package, fixes bug 1452902

### DIFF
--- a/fluent/__init__.py
+++ b/fluent/__init__.py
@@ -1,0 +1,1 @@
+__path__ = __import__('pkgutil').extend_path(__path__, __name__)


### PR DESCRIPTION
I tested this locally by installing the result in my tox envs of the compare-locales tests.

I tested this w/out 'fluent' in the setup.py packages, and that breaks, so I'm going for that in both fluent.syntax and fluent.migrate.