### PR TITLE
Create benchmark for fluent.runtime (fixes #85)

### DIFF
--- a/fluent.runtime/tools/benchmarks/README.md
+++ b/fluent.runtime/tools/benchmarks/README.md
@@ -1,0 +1,15 @@
+To run the benchmarks, do:
+
+    $ pip install -r tools/benchmarks/requirements.txt
+    $ py.test ./tools/benchmarks/fluent_benchmark.py::TestBenchmark --benchmark-warmup=on
+
+To profile the benchmark suite, we recommend py-spy as a
+good tool. Install py-spy: https://github.com/benfred/py-spy
+
+Then do something like this to profile the benchmark. Depending on your
+platform, you might need to use `sudo`.
+
+    $ py-spy -f prof.svg -- py.test ./tools/benchmarks/fluent_benchmark.py::TestBenchmark --benchmark-warmup=off
+
+And look at prof.svg in a browser. Note that this diagram includes the fixture
+setup, warmup and calibration phases which you should ignore.

--- a/fluent.runtime/tools/benchmarks/fluent_benchmark.py
+++ b/fluent.runtime/tools/benchmarks/fluent_benchmark.py
@@ -1,0 +1,70 @@
+#!/usr/bin/env python
+# This should be run using pytest
+
+from __future__ import unicode_literals
+
+import sys
+import pytest
+import six
+
+from fluent.runtime import FluentBundle
+
+
+FTL_CONTENT = """
+one = One
+two = Two
+three = Three
+four = Four
+five = Five
+six = Six
+seven = Seven ways to { $destination }
+eight = Eight
+nine = Nine
+ten = Ten
+"""
+
+@pytest.fixture
+def fluent_bundle():
+    ctx = FluentBundle(['pl'], use_isolating=False)
+    ctx.add_messages(FTL_CONTENT)
+    return ctx
+
+
+def fluent_template(bundle):
+    return (
+        "preface" +
+        bundle.format("one")[0] +
+        bundle.format("two")[0] +
+        bundle.format("three")[0] +
+        bundle.format("four")[0] +
+        bundle.format("five")[0] +
+        bundle.format("six")[0] +
+        bundle.format("seven", {"destination": "Mars"})[0] +
+        bundle.format("eight")[0] +
+        bundle.format("nine")[0] +
+        bundle.format("ten")[0] +
+        "tail"
+    )
+
+
+class TestBenchmark(object):
+    def test_template(self, fluent_bundle, benchmark):
+        result = benchmark(lambda: fluent_template(fluent_bundle))
+
+    def test_bundle(self, benchmark):
+        def test_bundles():
+            FluentBundle(['pl'], use_isolating=False)
+            FluentBundle(['fr'], use_isolating=False)
+        benchmark(test_bundles)
+
+    def test_import(self, benchmark):
+        def test_imports():
+            # prune cached imports
+            fluent_deps = [
+                k for k in sys.modules.keys()
+                if k.split('.', 1)[0] in ('babel','fluent','pytz')
+            ]
+            for k in fluent_deps:
+                del sys.modules[k]
+            from fluent.runtime import FluentBundle  # noqa
+        benchmark(test_imports)

--- a/fluent.runtime/tools/benchmarks/requirements.txt
+++ b/fluent.runtime/tools/benchmarks/requirements.txt
@@ -1,0 +1,2 @@
+pytest
+pytest-benchmark


### PR DESCRIPTION
I haven't figured out how to actually run this on travis.

I'd love if this would be extra jobs, maybe just on py2.7, py3.7, pypy2, pypy3?

Reminds me, we're not testing py3.7 at all yet, we need to. Which is partly #70.