### PR TITLE
Travis: Remove unused sudo:false setting

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,3 @@
-sudo: false
 language: python
 python:
   - "2.7"


### PR DESCRIPTION
This PR removes a now-unused Travis directive.