### PR TITLE
Refactor resolver into a tree of callable objects, or partially evaluated

### DIFF
--- a/fluent.runtime/fluent/runtime/__init__.py
+++ b/fluent.runtime/fluent/runtime/__init__.py
@@ -56,16 +56,19 @@ class FluentBundle(object):
             return False
         return message_id in self._messages_and_terms
 
+    def lookup(self, full_id):
+        if full_id not in self._compiled:
+            message = self._messages_and_terms[full_id]
+            self._compiled[full_id] = self._compiler(message.value)
+        return self._compiled[full_id]
+
     def format(self, message_id, args=None):
         if message_id.startswith(TERM_SIGIL):
             raise LookupError(message_id)
         if args is None:
             args = {}
-        if message_id not in self._compiled:
-            message = self._messages_and_terms[message_id]
-            self._compiled[message_id] = self._compiler(message.value)
-        resolve = self._compiled[message_id]
         errors = []
+        resolve = self.lookup(message_id)
         env = ResolverEnvironment(context=self,
                                   current=CurrentEnvironment(args=args),
                                   errors=errors)

--- a/fluent.runtime/fluent/runtime/__init__.py
+++ b/fluent.runtime/fluent/runtime/__init__.py
@@ -10,7 +10,7 @@ from fluent.syntax.ast import Message, Term
 from .builtins import BUILTINS
 from .prepare import Compiler
 from .resolver import ResolverEnvironment, CurrentEnvironment
-from .utils import ATTRIBUTE_SEPARATOR, TERM_SIGIL, add_message_and_attrs_to_store, ast_to_id
+from .utils import ATTRIBUTE_SEPARATOR, TERM_SIGIL, add_message_and_attrs_to_store, ast_to_id, native_to_fluent
 
 
 class FluentBundle(object):
@@ -65,12 +65,15 @@ class FluentBundle(object):
     def format(self, message_id, args=None):
         if message_id.startswith(TERM_SIGIL):
             raise LookupError(message_id)
-        if args is None:
-            args = {}
+        fluent_args = {}
+        if args is not None:
+            for argname, argvalue in args.items():
+                fluent_args[argname] = native_to_fluent(argvalue)
+
         errors = []
         resolve = self.lookup(message_id)
         env = ResolverEnvironment(context=self,
-                                  current=CurrentEnvironment(args=args),
+                                  current=CurrentEnvironment(args=fluent_args),
                                   errors=errors)
         return [resolve(env), errors]
 

--- a/fluent.runtime/fluent/runtime/__init__.py
+++ b/fluent.runtime/fluent/runtime/__init__.py
@@ -58,8 +58,13 @@ class FluentBundle(object):
 
     def lookup(self, full_id):
         if full_id not in self._compiled:
-            message = self._messages_and_terms[full_id]
-            self._compiled[full_id] = self._compiler(message.value)
+            entry_id = full_id.split(ATTRIBUTE_SEPARATOR, 1)[0]
+            entry = self._messages_and_terms[entry_id]
+            compiled = self._compiler(entry)
+            if compiled.value is not None:
+                self._compiled[entry_id] = compiled.value
+            for attr in compiled.attributes:
+                self._compiled[ATTRIBUTE_SEPARATOR.join([entry_id, attr.id.name])] = attr.value
         return self._compiled[full_id]
 
     def format(self, message_id, args=None):

--- a/fluent.runtime/fluent/runtime/__init__.py
+++ b/fluent.runtime/fluent/runtime/__init__.py
@@ -35,7 +35,7 @@ class FluentBundle(object):
         self._use_isolating = use_isolating
         self._messages_and_terms = {}
         self._compiled = {}
-        self._compiler = Compiler()
+        self._compiler = Compiler(use_isolating=use_isolating)
         self._babel_locale = self._get_babel_locale()
         self._plural_form = babel.plural.to_python(self._babel_locale.plural_form)
 

--- a/fluent.runtime/fluent/runtime/__init__.py
+++ b/fluent.runtime/fluent/runtime/__init__.py
@@ -10,7 +10,7 @@ from fluent.syntax.ast import Message, Term
 from .builtins import BUILTINS
 from .prepare import Compiler
 from .resolver import ResolverEnvironment, CurrentEnvironment
-from .utils import ATTRIBUTE_SEPARATOR, TERM_SIGIL, add_message_and_attrs_to_store, ast_to_id, native_to_fluent
+from .utils import ATTRIBUTE_SEPARATOR, TERM_SIGIL, ast_to_id, native_to_fluent
 
 
 class FluentBundle(object):
@@ -47,9 +47,7 @@ class FluentBundle(object):
             if isinstance(item, (Message, Term)):
                 full_id = ast_to_id(item)
                 if full_id not in self._messages_and_terms:
-                    # We add attributes to the store to enable faster looker
-                    # later, and more direct code in some instances.
-                    add_message_and_attrs_to_store(self._messages_and_terms, full_id, item)
+                    self._messages_and_terms[full_id] = item
 
     def has_message(self, message_id):
         if message_id.startswith(TERM_SIGIL) or ATTRIBUTE_SEPARATOR in message_id:

--- a/fluent.runtime/fluent/runtime/__init__.py
+++ b/fluent.runtime/fluent/runtime/__init__.py
@@ -68,10 +68,13 @@ class FluentBundle(object):
     def format(self, message_id, args=None):
         if message_id.startswith(TERM_SIGIL):
             raise LookupError(message_id)
-        fluent_args = {}
         if args is not None:
-            for argname, argvalue in args.items():
-                fluent_args[argname] = native_to_fluent(argvalue)
+            fluent_args = {
+                argname: native_to_fluent(argvalue)
+                for argname, argvalue in args.items()
+            }
+        else:
+            fluent_args = {}
 
         errors = []
         resolve = self.lookup(message_id)

--- a/fluent.runtime/fluent/runtime/prepare.py
+++ b/fluent.runtime/fluent/runtime/prepare.py
@@ -1,0 +1,45 @@
+from __future__ import absolute_import, unicode_literals
+from fluent.syntax import ast as FTL
+from . import resolver
+
+
+class Compiler(object):
+    def __init__(self, bundle=None):
+        self.bundle = None
+
+    def __call__(self, item):
+        if isinstance(item, FTL.BaseNode):
+            return self.compile(item)
+        if isinstance(item, (tuple, list)):
+            return [self(elem) for elem in item]
+        return item
+
+    def compile(self, node):
+        nodename = type(node).__name__
+        if not hasattr(resolver, nodename):
+            return node
+        kwargs = vars(node).copy()
+        for propname, propvalue in kwargs.items():
+            kwargs[propname] = self(propvalue)
+        handler = getattr(self, 'compile_' + nodename, self.compile_generic)
+        return handler(nodename, **kwargs)
+
+    def compile_generic(self, nodename, **kwargs):
+        return getattr(resolver, nodename)(**kwargs)
+
+    def compile_Placeable(self, _, expression, **kwargs):
+        if isinstance(expression, resolver.Literal):
+            return expression
+        return resolver.Placeable(expression=expression, **kwargs)
+
+    def compile_Pattern(self, _, elements, **kwargs):
+        if any(
+            not isinstance(child, resolver.Literal)
+            for child in elements
+        ):
+            return resolver.Pattern(elements=elements, **kwargs)
+        if len(elements) == 1:
+            return elements[0]
+        return resolver.TextElement(
+            ''.join(child(None) for child in elements)
+        )

--- a/fluent.runtime/fluent/runtime/prepare.py
+++ b/fluent.runtime/fluent/runtime/prepare.py
@@ -4,8 +4,7 @@ from . import resolver
 
 
 class Compiler(object):
-    def __init__(self, use_isolating=False, bundle=None):
-        self.bundle = None
+    def __init__(self, use_isolating=False):
         self.use_isolating = use_isolating
 
     def __call__(self, item):

--- a/fluent.runtime/fluent/runtime/resolver.py
+++ b/fluent.runtime/fluent/runtime/resolver.py
@@ -9,8 +9,8 @@ import six
 
 from fluent.syntax import ast as FTL
 from .errors import FluentCyclicReferenceError, FluentFormatError, FluentReferenceError
-from .types import FluentType, FluentDateType, FluentNone, FluentNumber, FluentInt, FluentFloat, fluent_date, fluent_number
-from .utils import numeric_to_native, reference_to_id, unknown_reference_error_obj
+from .types import FluentType, FluentNone, FluentInt, FluentFloat
+from .utils import reference_to_id, unknown_reference_error_obj
 
 
 text_type = six.text_type
@@ -111,6 +111,7 @@ class Pattern(FTL.Pattern, BaseResolver):
         self.dirty = False
         return retval
 
+
 def resolve(fluentish, env):
     if isinstance(fluentish, FluentType):
         return fluentish.format(env.context._babel_locale)
@@ -148,6 +149,7 @@ class NumberLiteral(FTL.NumberLiteral, BaseResolver):
             self.value = FluentFloat(self.value)
         else:
             self.value = FluentInt(self.value)
+
     def __call__(self, env):
         return self.value
 

--- a/fluent.runtime/fluent/runtime/resolver.py
+++ b/fluent.runtime/fluent/runtime/resolver.py
@@ -70,6 +70,14 @@ class ResolverEnvironment(object):
 
 
 class BaseResolver(object):
+    """
+    Abstract base class of all partially evaluated resolvers.
+
+    Subclasses should implement __call__, with a
+    ResolverEnvironment as parameter. An exception are wrapper
+    classes that don't show up in the evaluation, but need to
+    be part of the compiled tree structure.
+    """
     def __call__(self, env):
         raise NotImplementedError
 

--- a/fluent.runtime/fluent/runtime/resolver.py
+++ b/fluent.runtime/fluent/runtime/resolver.py
@@ -224,8 +224,8 @@ class Attribute(FTL.Attribute, BaseResolver):
     pass
 
 
-class VariantListResolver(BaseResolver):
-    def select_from_variant_list(self, env, key):
+class VariantList(FTL.VariantList, BaseResolver):
+    def __call__(self, env, key=None):
         found = None
         for variant in self.variants:
             if variant.default:
@@ -244,15 +244,9 @@ class VariantListResolver(BaseResolver):
                 env.errors.append(FluentReferenceError("Unknown variant: {0}"
                                                        .format(key)))
             found = default
-        if found is None:
-            return FluentNoneResolver()
+        assert found, "Not having a default variant is a parse error"
 
         return found.value(env)
-
-
-class VariantList(FTL.VariantList, VariantListResolver):
-    def __call__(self, env):
-        return self.select_from_variant_list(env, None)
 
 
 class SelectExpression(FTL.SelectExpression, BaseResolver):
@@ -313,7 +307,7 @@ class VariantExpression(FTL.VariantExpression, BaseResolver):
         assert isinstance(message, VariantList)
 
         variant_name = self.key.name
-        return message.select_from_variant_list(env, variant_name)
+        return message(env, variant_name)
 
 
 class CallExpression(FTL.CallExpression, BaseResolver):

--- a/fluent.runtime/fluent/runtime/resolver.py
+++ b/fluent.runtime/fluent/runtime/resolver.py
@@ -226,10 +226,10 @@ class VariableReference(FTL.VariableReference):
                       (int, float, Decimal,
                        date, datetime,
                        text_type)):
-            return lambda env: arg_val
+            return arg_val
         env.errors.append(TypeError("Unsupported external type: {0}, {1}"
                                     .format(name, type(arg_val))))
-        return FluentNoneResolver(name)
+        return FluentNone(name)
 
 
 class AttributeExpression(FTL.AttributeExpression, BaseResolver):

--- a/fluent.runtime/fluent/runtime/resolver.py
+++ b/fluent.runtime/fluent/runtime/resolver.py
@@ -9,7 +9,7 @@ import six
 
 from fluent.syntax import ast as FTL
 from .errors import FluentCyclicReferenceError, FluentFormatError, FluentReferenceError
-from .types import FluentType, FluentDateType, FluentNone, FluentNumber, fluent_date, fluent_number
+from .types import FluentType, FluentDateType, FluentNone, FluentNumber, FluentInt, FluentFloat, fluent_date, fluent_number
 from .utils import numeric_to_native, reference_to_id, unknown_reference_error_obj
 
 try:
@@ -146,7 +146,7 @@ class Pattern(FTL.Pattern, BaseResolver):
         return retval
 
     def resolve(self, fluentish, env):
-        if isinstance(fluentish, FluentType):
+        if isinstance(fluentish, (FluentType, FluentNumber)):
             return fluentish.format(env.context._babel_locale)
         return fluentish
 
@@ -166,7 +166,13 @@ class StringLiteral(FTL.StringLiteral, Literal):
         return self.value
 
 
-class NumberLiteral(FTL.NumberLiteral, Literal):
+class NumberLiteral(FTL.NumberLiteral, BaseResolver):
+    def __init__(self, value, **kwargs):
+        super(NumberLiteral, self).__init__(value, **kwargs)
+        if '.' in self.value:
+            self.value = FluentFloat(self.value)
+        else:
+            self.value = FluentInt(self.value)
     def __call__(self, env):
         return self.value
 

--- a/fluent.runtime/fluent/runtime/resolver.py
+++ b/fluent.runtime/fluent/runtime/resolver.py
@@ -194,7 +194,7 @@ def lookup_reference(ref, env):
     return FluentNoneResolver(ref_id)
 
 
-class VariableReference(FTL.VariableReference):
+class VariableReference(FTL.VariableReference, BaseResolver):
     def __call__(self, env):
         name = self.id.name
         try:
@@ -205,10 +205,7 @@ class VariableReference(FTL.VariableReference):
                     FluentReferenceError("Unknown external: {0}".format(name)))
             return FluentNoneResolver(name)
 
-        if isinstance(arg_val,
-                      (int, float, Decimal,
-                       date, datetime,
-                       text_type)):
+        if isinstance(arg_val, (FluentType, text_type)):
             return arg_val
         env.errors.append(TypeError("Unsupported external type: {0}, {1}"
                                     .format(name, type(arg_val))))

--- a/fluent.runtime/fluent/runtime/resolver.py
+++ b/fluent.runtime/fluent/runtime/resolver.py
@@ -140,15 +140,15 @@ class Pattern(FTL.Pattern, BaseResolver):
             return FluentNone()
         self.dirty = True
         retval = ''.join(
-            self.resolve(element(env), env) for element in self.elements
+            resolve(element(env), env) for element in self.elements
         )
         self.dirty = False
         return retval
 
-    def resolve(self, fluentish, env):
-        if isinstance(fluentish, (FluentType, FluentNumber)):
-            return fluentish.format(env.context._babel_locale)
-        return fluentish
+def resolve(fluentish, env):
+    if isinstance(fluentish, (FluentType, FluentNumber)):
+        return fluentish.format(env.context._babel_locale)
+    return fluentish
 
 
 class TextElement(FTL.TextElement, Literal):
@@ -159,6 +159,12 @@ class TextElement(FTL.TextElement, Literal):
 class Placeable(FTL.Placeable, BaseResolver):
     def __call__(self, env):
         return self.expression(env)
+
+
+class IsolatingPlaceable(FTL.Placeable, BaseResolver):
+    def __call__(self, env):
+        inner = self.expression(env)
+        return "\u2068" + resolve(inner, env) + "\u2069"
 
 
 class StringLiteral(FTL.StringLiteral, Literal):

--- a/fluent.runtime/fluent/runtime/resolver.py
+++ b/fluent.runtime/fluent/runtime/resolver.py
@@ -146,7 +146,7 @@ class Pattern(FTL.Pattern, BaseResolver):
         return retval
 
 def resolve(fluentish, env):
-    if isinstance(fluentish, (FluentType, FluentNumber)):
+    if isinstance(fluentish, FluentType):
         return fluentish.format(env.context._babel_locale)
     return fluentish
 

--- a/fluent.runtime/fluent/runtime/types.py
+++ b/fluent.runtime/fluent/runtime/types.py
@@ -81,7 +81,7 @@ class NumberFormatOptions(object):
     maximumSignificantDigits = attr.ib(default=None)
 
 
-class FluentNumber(object):
+class FluentNumber(FluentType):
 
     default_number_format_options = NumberFormatOptions()
 
@@ -276,7 +276,7 @@ class DateFormatOptions(object):
 _SUPPORTED_DATETIME_OPTIONS = ['dateStyle', 'timeStyle', 'timeZone']
 
 
-class FluentDateType(object):
+class FluentDateType(FluentType):
     # We need to match signature of `__init__` and `__new__` due to the way
     # some Python implementation (e.g. PyPy) implement some methods.
     # So we leave those alone, and implement another `_init_options`

--- a/fluent.runtime/fluent/runtime/utils.py
+++ b/fluent.runtime/fluent/runtime/utils.py
@@ -54,10 +54,10 @@ def native_to_fluent(val):
     if isinstance(val, Decimal):
         return FluentDecimal(val)
 
+    if isinstance(val, datetime):
+        return FluentDateTime.from_date_time(val)
     if isinstance(val, date):
         return FluentDate.from_date(val)
-    if isinstance(val, datetime):
-        return FluentDateTime.from_date(val)
     return val
 
 def reference_to_id(ref):

--- a/fluent.runtime/fluent/runtime/utils.py
+++ b/fluent.runtime/fluent/runtime/utils.py
@@ -31,18 +31,6 @@ def add_message_and_attrs_to_store(store, ref_id, item, is_parent=True):
                                            is_parent=False)
 
 
-def numeric_to_native(val):
-    """
-    Given a numeric string (as defined by fluent spec),
-    return an int or float
-    """
-    # val matches this EBNF:
-    #  '-'? [0-9]+ ('.' [0-9]+)?
-    if '.' in val:
-        return float(val)
-    return int(val)
-
-
 def native_to_fluent(val):
     """
     Convert a python type to a Fluent Type.
@@ -59,6 +47,7 @@ def native_to_fluent(val):
     if isinstance(val, date):
         return FluentDate.from_date(val)
     return val
+
 
 def reference_to_id(ref):
     """

--- a/fluent.runtime/fluent/runtime/utils.py
+++ b/fluent.runtime/fluent/runtime/utils.py
@@ -1,5 +1,11 @@
+from __future__ import absolute_import, unicode_literals
+
+from datetime import date, datetime
+from decimal import Decimal
+
 from fluent.syntax.ast import AttributeExpression, Term, TermReference
 
+from .types import FluentInt, FluentFloat, FluentDecimal, FluentDate, FluentDateTime
 from .errors import FluentReferenceError
 
 TERM_SIGIL = '-'
@@ -36,6 +42,23 @@ def numeric_to_native(val):
         return float(val)
     return int(val)
 
+
+def native_to_fluent(val):
+    """
+    Convert a python type to a Fluent Type.
+    """
+    if isinstance(val, int):
+        return FluentInt(val)
+    if isinstance(val, float):
+        return FluentFloat(val)
+    if isinstance(val, Decimal):
+        return FluentDecimal(val)
+
+    if isinstance(val, date):
+        return FluentDate.from_date(val)
+    if isinstance(val, datetime):
+        return FluentDateTime.from_date(val)
+    return val
 
 def reference_to_id(ref):
     """

--- a/fluent.runtime/fluent/runtime/utils.py
+++ b/fluent.runtime/fluent/runtime/utils.py
@@ -21,16 +21,6 @@ def ast_to_id(ast):
     return ast.id.name
 
 
-def add_message_and_attrs_to_store(store, ref_id, item, is_parent=True):
-    store[ref_id] = item
-    if is_parent:
-        for attr in item.attributes:
-            add_message_and_attrs_to_store(store,
-                                           _make_attr_id(ref_id, attr.id.name),
-                                           attr,
-                                           is_parent=False)
-
-
 def native_to_fluent(val):
     """
     Convert a python type to a Fluent Type.

--- a/fluent.runtime/setup.py
+++ b/fluent.runtime/setup.py
@@ -20,7 +20,7 @@ setup(name='fluent.runtime',
       ],
       packages=['fluent', 'fluent.runtime'],
       install_requires=[
-          'fluent.syntax>=0.10,<=0.11',
+          'fluent.syntax>=0.12,<=0.13',
           'attrs',
           'babel',
           'pytz',

--- a/fluent.runtime/setup.py
+++ b/fluent.runtime/setup.py
@@ -2,12 +2,6 @@
 from setuptools import setup
 import sys
 
-if sys.version_info < (3, 4):
-    extra_requires = ['singledispatch>=3.4']
-else:
-    # functools.singledispatch is in stdlib from Python 3.4 onwards.
-    extra_requires = []
-
 setup(name='fluent.runtime',
       version='0.1',
       description='Localization library for expressive translations.',
@@ -30,7 +24,7 @@ setup(name='fluent.runtime',
           'attrs',
           'babel',
           'pytz',
-      ] + extra_requires,
+      ],
       tests_require=['six'],
       test_suite='tests'
       )

--- a/fluent.runtime/tests/test_bomb.py
+++ b/fluent.runtime/tests/test_bomb.py
@@ -39,5 +39,5 @@ class TestBillionLaughs(unittest.TestCase):
         # Without protection, emptylolz will take a really long time to
         # evaluate, although it generates an empty message.
         val, errs = self.ctx.format('emptylolz')
-        self.assertEqual(val, '???')
+        self.assertEqual(val, '')
         self.assertEqual(len(errs), 1)

--- a/fluent.runtime/tox.ini
+++ b/fluent.runtime/tox.ini
@@ -6,10 +6,8 @@ skipsdist=True
 setenv =
     PYTHONPATH = {toxinidir}
 deps =
-     fluent.syntax>=0.10,<=0.11
+     fluent.syntax>=0.12,<=0.13
      six
      attrs
      Babel
-     py27: singledispatch
-     pypy: singledispatch
 commands = ./runtests.py


### PR DESCRIPTION
This is my all-test-passing state of the proposal I made in https://discourse.mozilla.org/t/python-fluent-runtime-plans/35290/10.

I've given this a try to see how this is doing before we do changes to the non-compiling API that don't perform, notably I'm looking at #92.

This isn't yet in a state where it can be reviewed, sadly, because I didn't get to remove unused code yet. I wouldn't be surprised if this could end up being the same amount of code in the end as the current dispatch resolver.

The good news is that in the template benchmark, I cut down mean and median to 50% of what they're on master right now.