### PR TITLE
Redo read-only visitor

### DIFF
--- a/fluent.syntax/fluent/syntax/ast.py
+++ b/fluent.syntax/fluent/syntax/ast.py
@@ -10,8 +10,8 @@ class Visitor(object):
     To generally define which nodes not to descend in to, overload
     `generic_visit`.
     To handle specific node types, add methods like `visit_Pattern`.
-    The boolean value of the returned value determines if the visitor
-    descends into the children of the given AST node.
+    If you want to still descend into the children of the node, call
+    `generic_visit` of the superclass.
     '''
     def visit(self, node):
         if isinstance(node, list):
@@ -22,14 +22,11 @@ class Visitor(object):
             return
         nodename = type(node).__name__
         visit = getattr(self, 'visit_{}'.format(nodename), self.generic_visit)
-        should_descend = visit(node)
-        if not should_descend:
-            return
-        for propname, propvalue in vars(node).items():
-            self.visit(propvalue)
+        visit(node)
 
     def generic_visit(self, node):
-        return True
+        for propname, propvalue in vars(node).items():
+            self.visit(propvalue)
 
 
 class Transformer(Visitor):

--- a/fluent.syntax/tests/syntax/test_visitor.py
+++ b/fluent.syntax/tests/syntax/test_visitor.py
@@ -18,11 +18,10 @@ class MockVisitor(ast.Visitor):
 
     def generic_visit(self, node):
         self.calls[type(node).__name__] += 1
-        return super(MockVisitor, self).generic_visit(node)
+        super(MockVisitor, self).generic_visit(node)
 
     def visit_Pattern(self, node):
         self.pattern_calls += 1
-        return False
 
 
 class TestVisitor(unittest.TestCase):
@@ -87,11 +86,11 @@ class VisitorCounter(ast.Visitor):
         self.word_count = 0
 
     def generic_visit(self, node):
-        return not isinstance(node, (ast.Span, ast.Annotation))
+        if not isinstance(node, (ast.Span, ast.Annotation)):
+            super(VisitorCounter, self).generic_visit(node)
 
     def visit_TextElement(self, node):
         self.word_count += len(node.value.split())
-        return False
 
 
 class ReplaceText(object):


### PR DESCRIPTION
I'm having second thoughts about the ast.Visitor.

I've tested https://phabricator.services.mozilla.com/D19137, and turns out that setting the state in the current visit is really hard. Mostly, because there's no natural per-Node pop.

Now, if I redo the visitor, it's closer to how Transformer works, and easier to do things like "I'm in NodeX" state. The code in c-l now becomes

```python

    def visit_AttributeExpression(self, node):
        # keep track that we're in an AttributeExpression
        self.attr = '.' + node.name.name
        super(ReferenceCollector, self).generic_visit(node)
        self.attr = ''

    def visit_MessageReference(self, node):
        self.refs[node.id.name + self.attr] = node

    def visit_TermReference(self, node):
        # only collect term references, but not attributes of terms
        if not self.attr:
            self.refs['-' + node.id.name] = node
```

The code in D19137 actually fails tests if the `AttributeReference.ref` isn't the first node to dive in to. Which it is on py2, but not on py3. That's how hard it is to do state. In the current node, you just set the attribute for all children of the attribute reference, which we know is OK. A lot less assumptions on AST structure. The alternative was to introduce a stack state by overloading visit, and that was ugly.

@stasm, what do you think?