### PR TITLE
Fixed regression with variant expressions involving missing terms

### DIFF
--- a/fluent.runtime/fluent/runtime/resolver.py
+++ b/fluent.runtime/fluent/runtime/resolver.py
@@ -315,9 +315,9 @@ class VariantExpression(FTL.VariantExpression, BaseResolver):
     def __call__(self, env):
         message = lookup_reference(self.ref, env)
 
-        # TODO What to do if message is not a VariantList?
-        # Need test at least.
-        assert isinstance(message, VariantList)
+        if not isinstance(message, VariantList):
+            # Must be FluentNoneResolver
+            return message(env)
 
         variant_name = self.key.name
         return message(env, variant_name)

--- a/fluent.runtime/tests/format/test_variants.py
+++ b/fluent.runtime/tests/format/test_variants.py
@@ -21,6 +21,7 @@ class TestVariants(unittest.TestCase):
             bar = { -variant[a] }
             baz = { -variant[b] }
             qux = { -variant[c] }
+            goo = { -missing[a] }
         """))
 
     def test_returns_the_default_variant(self):
@@ -45,3 +46,11 @@ class TestVariants(unittest.TestCase):
         self.assertEqual(
             errs,
             [FluentReferenceError("Unknown variant: c")])
+
+    def test_choose_missing_term(self):
+        val, errs = self.ctx.format('goo', {})
+        self.assertEqual(val, '-missing')
+        self.assertEqual(len(errs), 1)
+        self.assertEqual(
+            errs,
+            [FluentReferenceError("Unknown term: -missing")])


### PR DESCRIPTION
I'm not sure what exact code re-organisation caused this, but it is a regression as far as I can tell.

Interestingly, I caught this when re-basing my compiler branch onto master (with the re-worked resolver implementation). In the compiler branch I added a test purely to handle a corner case in the compiler implementation - the resolver already passed that  test and didn't need to be changed. With the changed resolver implementation, that test caught a new corner case. This is an illustration of how the two implementations can help each other (tests added only for one end up catching bugs in the other), and an argument in favour of keeping the two implementations in one code base, so they can share a test suite (@stasm we talked about this).