### PR TITLE
Test case for regression involving single element placeables

### DIFF
--- a/fluent.runtime/tests/format/test_placeables.py
+++ b/fluent.runtime/tests/format/test_placeables.py
@@ -109,3 +109,47 @@ class TestPlaceables(unittest.TestCase):
         val, errs = self.ctx.format('self-parent-ref-ok.attr', {})
         self.assertEqual(val, 'Attribute Parent')
         self.assertEqual(len(errs), 0)
+
+
+class TestSingleElementPattern(unittest.TestCase):
+    def test_single_literal_number_isolating(self):
+        self.ctx = FluentBundle(['en-US'], use_isolating=True)
+        self.ctx.add_messages('foo = { 1 }')
+        val, errs = self.ctx.format('foo')
+        self.assertEqual(val, '1')
+        self.assertEqual(errs, [])
+
+    def test_single_literal_number_non_isolating(self):
+        self.ctx = FluentBundle(['en-US'], use_isolating=False)
+        self.ctx.add_messages('foo = { 1 }')
+        val, errs = self.ctx.format('foo')
+        self.assertEqual(val, '1')
+        self.assertEqual(errs, [])
+
+    def test_single_arg_number_isolating(self):
+        self.ctx = FluentBundle(['en-US'], use_isolating=True)
+        self.ctx.add_messages('foo = { $arg }')
+        val, errs = self.ctx.format('foo', {'arg': 1})
+        self.assertEqual(val, '1')
+        self.assertEqual(errs, [])
+
+    def test_single_arg_number_non_isolating(self):
+        self.ctx = FluentBundle(['en-US'], use_isolating=False)
+        self.ctx.add_messages('foo = { $arg }')
+        val, errs = self.ctx.format('foo', {'arg': 1})
+        self.assertEqual(val, '1')
+        self.assertEqual(errs, [])
+
+    def test_single_arg_missing_isolating(self):
+        self.ctx = FluentBundle(['en-US'], use_isolating=True)
+        self.ctx.add_messages('foo = { $arg }')
+        val, errs = self.ctx.format('foo')
+        self.assertEqual(val, 'arg')
+        self.assertEqual(len(errs), 1)
+
+    def test_single_arg_missing_non_isolating(self):
+        self.ctx = FluentBundle(['en-US'], use_isolating=False)
+        self.ctx.add_messages('foo = { $arg }')
+        val, errs = self.ctx.format('foo')
+        self.assertEqual(val, 'arg')
+        self.assertEqual(len(errs), 1)


### PR DESCRIPTION
This looks like a regression @Pike  (I have another one coming too, sorry to do that to you on a Friday afternoon...!). Numbers and `FluentNone` are not getting turned into strings as they should.

I realized I didn't understand your new implementation as well as I need to, especially in terms of at what point things get resolved, so I was trying to add some specific tests and came across some issues.

Only 3 of these tests fail (those with `use_isolating=True`), the others are there for good measure.

I think you probably have a better idea how to fix these at this point in time, shall I leave them with you?