### PR TITLE
Thread safety regression.

### DIFF
--- a/fluent.runtime/tests/format/test_thread_safety.py
+++ b/fluent.runtime/tests/format/test_thread_safety.py
@@ -1,0 +1,50 @@
+from __future__ import absolute_import, unicode_literals
+
+import threading
+import unittest
+
+from ..utils import dedent_ftl
+
+from fluent.runtime import FluentBundle
+
+from unittest.mock import patch
+import time
+
+
+class TestThreadSafety(unittest.TestCase):
+    def setUp(self):
+        self.ctx = FluentBundle(['en-US'], use_isolating=False)
+        self.ctx.add_messages(dedent_ftl("""
+            foo = Foo
+            foo-bar = { foo } Bar
+        """))
+
+    def test_is_dirty_isolation(self):
+        count = 0
+        all_errs = []
+
+        from fluent.runtime.resolver import resolve as original_resolve
+
+        def new_resolve(fluentish, env):
+            time.sleep(0.1)
+            return original_resolve(fluentish, env)
+
+        def run():
+            val, errs = self.ctx.format('foo-bar', {})
+            all_errs.extend(errs)
+
+        with patch('fluent.runtime.resolver.resolve', new=new_resolve):
+            while count < 20 and len(all_errs) == 0:
+                count += 1
+                threads = []
+
+                for i in range(0, 100):
+                    threads.append(threading.Thread(target=run))
+
+                for t in threads:
+                    t.start()
+                for t in threads:
+                    t.join()
+
+        if all_errs:
+            self.fail(all_errs[0])


### PR DESCRIPTION
This PR is to demonstrate a thread safety issue with the new resolver, I'm not intending that this test should really be added to the test suite because you can't really prove threading issues are absent with tests.

The race happens between these lines:

https://github.com/projectfluent/python-fluent/blob/master/fluent.runtime/fluent/runtime/resolver.py#L116
https://github.com/projectfluent/python-fluent/blob/master/fluent.runtime/fluent/runtime/resolver.py#L127

i.e. the `self.is_dirty` changes. This is because for a given message, in some cases at least a single `Pattern` object is now stored in `FluentBundle._compiled`, which gets shared between threads if the bundle is shared. Previously, the resolver stored this state in the `ResolverEnvironment`, for which you get a new copy every time you call `format`.

The test has to monkey patch the `resolve` function to slow it down using `time.sleep` in order to demonstrate the issue. Other ways to see it are to add `logging.error` calls in between the `self.is_dirty` changes.

