### PR TITLE
fluent.runtime - broader dependency range for fluent.syntax

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,10 +9,29 @@ python:
   - "pypy3.5-6.0"
   - "nightly"
 env:
-  - PACKAGE=fluent.syntax
-  - PACKAGE=fluent.runtime
-install: pip install tox-travis
-script: cd $PACKAGE; tox
+  global:
+    - FLUENT_RUNTIME_DEFAULT_DEPS="fluent.syntax==0.12.0 attrs==19.1.0 babel==2.6.0 pytz==2018.9 six==1.12.0"
+    - FLUENT_SYNTAX_DEFAULT_DEPS="six"
+  matrix:
+    - PACKAGE=fluent.syntax
+    - PACKAGE=fluent.runtime
+matrix:
+  include:
+  - name: "fluent.runtime w/ fluent.syntax==0.10"
+    python: "3.6"
+    env: PACKAGE=fluent.runtime TEST_DEPS="fluent.syntax==0.10.0 attrs==19.1.0 babel==2.6.0 pytz==2018.9 six==1.12.0"
+  - name: "fluent.runtime with latest everything"
+    python: "3.6"
+    # These are copy-pasted from setup.py
+    env: PACKAGE=fluent.runtime TEST_DEPS="fluent.syntax>=0.10,<=0.13 attrs babel pytz six"
+  allow_failures:
+  - python: "3.6"
+    env: PACKAGE=fluent.runtime TEST_DEPS="fluent.syntax>=0.10,<=0.13 attrs babel pytz six"
+
+install:
+  - if [ "$PACKAGE" = "fluent.runtime" ]; then TEST_DEPS=${TEST_DEPS:-$FLUENT_RUNTIME_DEFAULT_DEPS}; else TEST_DEPS=${TEST_DEPS:-$FLUENT_SYNTAX_DEFAULT_DEPS}; fi
+  - pip install $TEST_DEPS
+script: cd $PACKAGE; ./runtests.py
 notifications:
   irc:
     channels:

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,7 @@ python:
   - "nightly"
 env:
   global:
-    - FLUENT_RUNTIME_DEFAULT_DEPS="fluent.syntax==0.12.0 attrs==19.1.0 babel==2.6.0 pytz==2018.9 six==1.12.0"
+    - FLUENT_RUNTIME_DEFAULT_DEPS="fluent.syntax==0.13.0 attrs==19.1.0 babel==2.6.0 pytz==2018.9 six==1.12.0"
     - FLUENT_SYNTAX_DEFAULT_DEPS="six"
   matrix:
     - PACKAGE=fluent.syntax

--- a/fluent.runtime/setup.py
+++ b/fluent.runtime/setup.py
@@ -1,6 +1,5 @@
 #!/usr/bin/env python
 from setuptools import setup
-import sys
 
 
 setup(name='fluent.runtime',
@@ -21,7 +20,7 @@ setup(name='fluent.runtime',
       ],
       packages=['fluent', 'fluent.runtime'],
       install_requires=[
-          'fluent.syntax>=0.12,<=0.13',
+          'fluent.syntax>=0.10,<=0.13',
           'attrs',
           'babel',
           'pytz',

--- a/fluent.runtime/setup.py
+++ b/fluent.runtime/setup.py
@@ -19,7 +19,7 @@ setup(name='fluent.runtime',
           'Programming Language :: Python :: 3.5',
       ],
       packages=['fluent', 'fluent.runtime'],
-      # These should also be duplicated in tox.ini
+      # These should also be duplicated in tox.ini and ../.travis.yml
       install_requires=[
           'fluent.syntax>=0.10,<=0.13',
           'attrs',

--- a/fluent.runtime/setup.py
+++ b/fluent.runtime/setup.py
@@ -19,6 +19,7 @@ setup(name='fluent.runtime',
           'Programming Language :: Python :: 3.5',
       ],
       packages=['fluent', 'fluent.runtime'],
+      # These should also be duplicated in tox.ini
       install_requires=[
           'fluent.syntax>=0.10,<=0.13',
           'attrs',

--- a/fluent.runtime/tox.ini
+++ b/fluent.runtime/tox.ini
@@ -1,3 +1,4 @@
+# This config is for local testing. It should be duplicated into .travis.yml
 [tox]
 envlist = {py27, py35, py36, py37, pypy, pypy3}-syntax0.12, py36-syntax0.10, latest
 skipsdist=True
@@ -6,12 +7,12 @@ skipsdist=True
 setenv =
     PYTHONPATH = {toxinidir}
 deps =
+     syntax0.10: fluent.syntax==0.10.0
+     syntax0.12: fluent.syntax==0.12.0
      attrs==19.1.0
      babel==2.6.0
      pytz==2018.9
      six==1.12.0
-     syntax0.10: fluent.syntax==0.10.0
-     syntax0.12: fluent.syntax==0.12.0
 commands = ./runtests.py
 
 [testenv:latest]
@@ -20,7 +21,7 @@ deps =
      # Here we try to reproduce what a user gets if they do 'pip install fluent.runtime'
      # It's tempting to use '.' here to get 'pip install .'
      # Unfortunately it is super slow: https://github.com/pypa/pip/issues/2195
-     # Instead we define the same requirements as in setup.py
+     # Instead we copy-paste from setup.py
      fluent.syntax>=0.10,<=0.13
      attrs
      babel

--- a/fluent.runtime/tox.ini
+++ b/fluent.runtime/tox.ini
@@ -1,6 +1,6 @@
 # This config is for local testing. It should be duplicated into .travis.yml
 [tox]
-envlist = {py27, py35, py36, py37, pypy, pypy3}-syntax0.13, py36-syntax0.10, latest
+envlist = {py27,py35,py36,py37,pypy,pypy3}-syntax0.13, py36-syntax0.10, latest
 skipsdist=True
 
 [testenv]

--- a/fluent.runtime/tox.ini
+++ b/fluent.runtime/tox.ini
@@ -1,10 +1,28 @@
 [tox]
-envlist = py27, py35, py36, py37, pypy, pypy3
+envlist = {py27, py35, py36, py37, pypy, pypy3}-syntax0.12, py36-syntax0.10, latest
 skipsdist=True
 
 [testenv]
 setenv =
     PYTHONPATH = {toxinidir}
 deps =
-     .
+     attrs==19.1.0
+     babel==2.6.0
+     pytz==2018.9
+     six==1.12.0
+     syntax0.10: fluent.syntax==0.10.0
+     syntax0.12: fluent.syntax==0.12.0
 commands = ./runtests.py
+
+[testenv:latest]
+basepython = python3.6
+deps =
+     # Here we try to reproduce what a user gets if they do 'pip install fluent.runtime'
+     # It's tempting to use '.' here to get 'pip install .'
+     # Unfortunately it is super slow: https://github.com/pypa/pip/issues/2195
+     # Instead we define the same requirements as in setup.py
+     fluent.syntax>=0.10,<=0.13
+     attrs
+     babel
+     pytz
+     six

--- a/fluent.runtime/tox.ini
+++ b/fluent.runtime/tox.ini
@@ -1,6 +1,6 @@
 # This config is for local testing. It should be duplicated into .travis.yml
 [tox]
-envlist = {py27, py35, py36, py37, pypy, pypy3}-syntax0.12, py36-syntax0.10, latest
+envlist = {py27, py35, py36, py37, pypy, pypy3}-syntax0.13, py36-syntax0.10, latest
 skipsdist=True
 
 [testenv]
@@ -8,7 +8,7 @@ setenv =
     PYTHONPATH = {toxinidir}
 deps =
      syntax0.10: fluent.syntax==0.10.0
-     syntax0.12: fluent.syntax==0.12.0
+     syntax0.13: fluent.syntax==0.13.0
      attrs==19.1.0
      babel==2.6.0
      pytz==2018.9

--- a/fluent.syntax/setup.py
+++ b/fluent.syntax/setup.py
@@ -18,6 +18,7 @@ setup(name='fluent.syntax',
           'Programming Language :: Python :: 3.5',
       ],
       packages=['fluent', 'fluent.syntax'],
+      # These should also be duplicated in tox.ini and ../.travis.yml
       tests_require=['six'],
       test_suite='tests.syntax'
 )

--- a/fluent.syntax/tox.ini
+++ b/fluent.syntax/tox.ini
@@ -1,3 +1,4 @@
+# This config is for local testing. It should be duplicated into .travis.yml
 [tox]
 envlist = py27, py35, py36, py37, pypy, pypy3
 skipsdist=True


### PR DESCRIPTION
We don't actually depend on anything that was added after 0.10, and a tight check gives problems with other tools (e.g. compare-locales is constrained to '>=0.10,<0.11').

