### PR TITLE
.equals should not ignore Variant and Attribute order, fixes #111

### DIFF
--- a/fluent.syntax/fluent/syntax/ast.py
+++ b/fluent.syntax/fluent/syntax/ast.py
@@ -183,13 +183,6 @@ class BaseNode(object):
                 if len(field1) != len(field2):
                     return False
 
-                # Sort elements of order-agnostic fields to ensure the
-                # comparison is order-agnostic as well. Annotations should be
-                # here too but they don't have sorting keys.
-                if key in ('attributes', 'variants'):
-                    field1 = sorted(field1, key=lambda elem: elem.sorting_key)
-                    field2 = sorted(field2, key=lambda elem: elem.sorting_key)
-
                 for elem1, elem2 in zip(field1, field2):
                     if not scalars_equal(elem1, elem2, ignored_fields):
                         return False
@@ -358,10 +351,6 @@ class Attribute(SyntaxNode):
         self.id = id
         self.value = value
 
-    @property
-    def sorting_key(self):
-        return self.id.name
-
 
 class Variant(SyntaxNode):
     def __init__(self, key, value, default=False, **kwargs):
@@ -369,12 +358,6 @@ class Variant(SyntaxNode):
         self.key = key
         self.value = value
         self.default = default
-
-    @property
-    def sorting_key(self):
-        if isinstance(self.key, NumberLiteral):
-            return self.key.value
-        return self.key.name
 
 
 class NamedArgument(SyntaxNode):

--- a/fluent.syntax/tests/syntax/test_equals.py
+++ b/fluent.syntax/tests/syntax/test_equals.py
@@ -84,7 +84,7 @@ class TestEntryEqualToSelf(unittest.TestCase):
         self.assertTrue(message1.equals(message1.clone()))
 
 
-class TestOrderEquals(unittest.TestCase):
+class TestNonEquals(unittest.TestCase):
     def setUp(self):
         self.parser = FluentParser()
 
@@ -103,8 +103,7 @@ class TestOrderEquals(unittest.TestCase):
                 .attr1 = Attr1
         """)
 
-        self.assertTrue(message1.equals(message2))
-        self.assertTrue(message2.equals(message1))
+        self.assertFalse(message1.equals(message2))
 
     def test_variants(self):
         message1 = self.parse_ftl_entry("""\
@@ -122,8 +121,7 @@ class TestOrderEquals(unittest.TestCase):
                 }
         """)
 
-        self.assertTrue(message1.equals(message2))
-        self.assertTrue(message2.equals(message1))
+        self.assertFalse(message1.equals(message2))
 
     def test_variants_with_numbers(self):
         message1 = self.parse_ftl_entry("""\
@@ -141,8 +139,7 @@ class TestOrderEquals(unittest.TestCase):
                 }
         """)
 
-        self.assertTrue(message1.equals(message2))
-        self.assertTrue(message2.equals(message1))
+        self.assertFalse(message1.equals(message2))
 
 
 class TestEqualWithSpans(unittest.TestCase):


### PR DESCRIPTION
This goes back to the conversation in https://github.com/projectfluent/fluent.js/pull/172