### PR TITLE
Make resolver threadsaf(er) again, fix isolation

### DIFF
--- a/fluent.runtime/fluent/runtime/__init__.py
+++ b/fluent.runtime/fluent/runtime/__init__.py
@@ -32,10 +32,10 @@ class FluentBundle(object):
         if functions:
             _functions.update(functions)
         self._functions = _functions
-        self._use_isolating = use_isolating
+        self.use_isolating = use_isolating
         self._messages_and_terms = {}
         self._compiled = {}
-        self._compiler = Compiler(use_isolating=use_isolating)
+        self._compiler = Compiler()
         self._babel_locale = self._get_babel_locale()
         self._plural_form = babel.plural.to_python(self._babel_locale.plural_form)
 

--- a/fluent.runtime/fluent/runtime/prepare.py
+++ b/fluent.runtime/fluent/runtime/prepare.py
@@ -4,9 +4,6 @@ from . import resolver
 
 
 class Compiler(object):
-    def __init__(self, use_isolating=False):
-        self.use_isolating = use_isolating
-
     def __call__(self, item):
         if isinstance(item, FTL.BaseNode):
             return self.compile(item)
@@ -28,8 +25,6 @@ class Compiler(object):
         return getattr(resolver, nodename)(**kwargs)
 
     def compile_Placeable(self, _, expression, **kwargs):
-        if self.use_isolating:
-            return resolver.IsolatingPlaceable(expression=expression, **kwargs)
         if isinstance(expression, resolver.Literal):
             return expression
         return resolver.Placeable(expression=expression, **kwargs)
@@ -37,10 +32,10 @@ class Compiler(object):
     def compile_Pattern(self, _, elements, **kwargs):
         if (
             len(elements) == 1 and
-            isinstance(elements[0], resolver.IsolatingPlaceable)
+            isinstance(elements[0], resolver.Placeable)
         ):
             # Don't isolate isolated placeables
-            return elements[0].expression
+            return resolver.NeverIsolatingPlaceable(elements[0].expression)
         if any(
             not isinstance(child, resolver.Literal)
             for child in elements

--- a/fluent.runtime/tests/format/test_placeables.py
+++ b/fluent.runtime/tests/format/test_placeables.py
@@ -109,3 +109,47 @@ class TestPlaceables(unittest.TestCase):
         val, errs = self.ctx.format('self-parent-ref-ok.attr', {})
         self.assertEqual(val, 'Attribute Parent')
         self.assertEqual(len(errs), 0)
+
+
+class TestSingleElementPattern(unittest.TestCase):
+    def test_single_literal_number_isolating(self):
+        self.ctx = FluentBundle(['en-US'], use_isolating=True)
+        self.ctx.add_messages('foo = { 1 }')
+        val, errs = self.ctx.format('foo')
+        self.assertEqual(val, '1')
+        self.assertEqual(errs, [])
+
+    def test_single_literal_number_non_isolating(self):
+        self.ctx = FluentBundle(['en-US'], use_isolating=False)
+        self.ctx.add_messages('foo = { 1 }')
+        val, errs = self.ctx.format('foo')
+        self.assertEqual(val, '1')
+        self.assertEqual(errs, [])
+
+    def test_single_arg_number_isolating(self):
+        self.ctx = FluentBundle(['en-US'], use_isolating=True)
+        self.ctx.add_messages('foo = { $arg }')
+        val, errs = self.ctx.format('foo', {'arg': 1})
+        self.assertEqual(val, '1')
+        self.assertEqual(errs, [])
+
+    def test_single_arg_number_non_isolating(self):
+        self.ctx = FluentBundle(['en-US'], use_isolating=False)
+        self.ctx.add_messages('foo = { $arg }')
+        val, errs = self.ctx.format('foo', {'arg': 1})
+        self.assertEqual(val, '1')
+        self.assertEqual(errs, [])
+
+    def test_single_arg_missing_isolating(self):
+        self.ctx = FluentBundle(['en-US'], use_isolating=True)
+        self.ctx.add_messages('foo = { $arg }')
+        val, errs = self.ctx.format('foo')
+        self.assertEqual(val, 'arg')
+        self.assertEqual(len(errs), 1)
+
+    def test_single_arg_missing_non_isolating(self):
+        self.ctx = FluentBundle(['en-US'], use_isolating=False)
+        self.ctx.add_messages('foo = { $arg }')
+        val, errs = self.ctx.format('foo')
+        self.assertEqual(val, 'arg')
+        self.assertEqual(len(errs), 1)


### PR DESCRIPTION
This patch removes state from the compiled tree.
For one, the recursion detection on patterns keeps its state in
the `ResolverEnvironment` now, instead of in the compiled tree.
Also, the question of bidi isolation is now kept in the resolver
context, instead of in the compiled tree.
For single placeables, which don't get bidi-isolated ever, there's
now a distinct NeverIsolatingPlaceable, which also takes care of
resolving fluent values to strings.

This should fix the test cases in #108 and #109

Luke, picking this up again, does this look good?

FWIW, I call this "threadsafer" as I think there might still be race conditions inside `FluentBundle.lookup`. I'm not sure they're bad, though. I think the worst case is that we compile a message twice, and then use the message value and attributes from different threads. They should be equivalent objects, though.