### PR TITLE
Use `split` instead of `splitlines` to serialize comments (fixes #119)

### DIFF
--- a/fluent.syntax/fluent/syntax/serializer.py
+++ b/fluent.syntax/fluent/syntax/serializer.py
@@ -64,7 +64,7 @@ class FluentSerializer(object):
 def serialize_comment(comment, prefix="#"):
     prefixed = "\n".join([
         prefix if len(line) == 0 else "{} {}".format(prefix, line)
-        for line in comment.content.splitlines(False)
+        for line in comment.content.split("\n")
     ])
     # Add the trailing line break.
     return '{}\n'.format(prefixed)

--- a/fluent.syntax/tests/syntax/test_serializer.py
+++ b/fluent.syntax/tests/syntax/test_serializer.py
@@ -115,6 +115,8 @@ class TestSerializeResource(unittest.TestCase):
             # A multiline
             # message comment.
             foo = Foo
+            #
+            bar = Bar
         """
         self.assertEqual(self.pretty_ftl(input), dedent_ftl(input))
 
@@ -128,6 +130,10 @@ class TestSerializeResource(unittest.TestCase):
             ## group comment.
 
             bar = Bar
+
+            ##
+
+            baz = Baz
         """
         self.assertEqual(self.pretty_ftl(input), dedent_ftl(input))
 


### PR DESCRIPTION
`splitlines` returns `[]` for empty strings, which is not what we
want, use `split` instead.

This matches what `@fluent.syntax` does on the js side.

Zibi, can you do a review on this one?