### PR TITLE
Allow whitespace before CallArguments (fixes #124)

### DIFF
--- a/fluent.syntax/fluent/syntax/parser.py
+++ b/fluent.syntax/fluent/syntax/parser.py
@@ -564,17 +564,21 @@ class FluentParser(object):
                 ps.next()
                 attribute = self.get_identifier(ps)
             arguments = None
-            if ps.current_char == '(':
+            ps.peek_blank()
+            if ps.current_peek == '(':
+                ps.skip_to_peek()
                 arguments = self.get_call_arguments(ps)
             return ast.TermReference(id, attribute, arguments)
 
         if ps.is_identifier_start():
             id = self.get_identifier(ps)
+            ps.peek_blank()
 
-            if ps.current_char == '(':
+            if ps.current_peek == '(':
                 # It's a Function. Ensure it's all upper-case.
                 if not re.match('^[A-Z][A-Z0-9_-]*$', id.name):
                     raise ParseError('E0008')
+                ps.skip_to_peek()
                 args = self.get_call_arguments(ps)
                 return ast.FunctionReference(id, args)
 

--- a/fluent.syntax/tests/syntax/fixtures_reference/call_expressions.ftl
+++ b/fluent.syntax/tests/syntax/fixtures_reference/call_expressions.ftl
@@ -29,14 +29,15 @@ duplicate-named-args = {FUN(x: 1, x: "X")}
 
 ## Whitespace around arguments
 
-sparse-inline-call = {FUN(  "a"  , msg,   x: 1   )}
+sparse-inline-call = {FUN     (  "a"  , msg,   x: 1   )}
 empty-inline-call = {FUN(  )}
 multiline-call = {FUN(
         "a",
         msg,
         x: 1
     )}
-sparse-multiline-call = {FUN(
+sparse-multiline-call = {FUN
+    (
 
         "a"    ,
         msg

--- a/fluent.syntax/tests/syntax/fixtures_reference/comments.ftl
+++ b/fluent.syntax/tests/syntax/fixtures_reference/comments.ftl
@@ -9,7 +9,12 @@ foo = Foo
 -term = Term
 
 # Another standalone
-#
+# 
 #      with indent
 ## Group Comment
 ### Resource Comment
+
+# Errors
+#error
+##error
+###error

--- a/fluent.syntax/tests/syntax/fixtures_reference/comments.json
+++ b/fluent.syntax/tests/syntax/fixtures_reference/comments.json
@@ -58,6 +58,25 @@
         {
             "type": "ResourceComment",
             "content": "Resource Comment"
+        },
+        {
+            "type": "Comment",
+            "content": "Errors"
+        },
+        {
+            "type": "Junk",
+            "annotations": [],
+            "content": "#error\n"
+        },
+        {
+            "type": "Junk",
+            "annotations": [],
+            "content": "##error\n"
+        },
+        {
+            "type": "Junk",
+            "annotations": [],
+            "content": "###error\n"
         }
     ]
 }

--- a/fluent.syntax/tests/syntax/fixtures_reference/escaped_characters.ftl
+++ b/fluent.syntax/tests/syntax/fixtures_reference/escaped_characters.ftl
@@ -12,6 +12,9 @@ backslash-in-string = {"\\"}
 mismatched-quote = {"\\""}
 # ERROR Unknown escape
 unknown-escape = {"\x"}
+# ERROR Multiline literal
+invalid-multiline-literal = {"
+ "}
 
 ## Unicode escapes
 string-unicode-4digits = {"\u0041"}

--- a/fluent.syntax/tests/syntax/fixtures_reference/escaped_characters.json
+++ b/fluent.syntax/tests/syntax/fixtures_reference/escaped_characters.json
@@ -168,7 +168,16 @@
         {
             "type": "Junk",
             "annotations": [],
-            "content": "unknown-escape = {\"\\x\"}\n\n"
+            "content": "unknown-escape = {\"\\x\"}\n"
+        },
+        {
+            "type": "Comment",
+            "content": "ERROR Multiline literal"
+        },
+        {
+            "type": "Junk",
+            "annotations": [],
+            "content": "invalid-multiline-literal = {\"\n \"}\n\n"
         },
         {
             "type": "GroupComment",

--- a/fluent.syntax/tests/syntax/fixtures_reference/messages.ftl
+++ b/fluent.syntax/tests/syntax/fixtures_reference/messages.ftl
@@ -18,6 +18,12 @@ key04 =
 key05 =                
     .attr1 = Attribute 1
 
+no-whitespace=Value
+    .attr1=Attribute 1
+
+extra-whitespace    =  Value
+    .attr1   =      Attribute 1
+
 key06 = {""}
 
 # JUNK Missing value

--- a/fluent.syntax/tests/syntax/fixtures_reference/messages.json
+++ b/fluent.syntax/tests/syntax/fixtures_reference/messages.json
@@ -209,6 +209,76 @@
             "type": "Message",
             "id": {
                 "type": "Identifier",
+                "name": "no-whitespace"
+            },
+            "value": {
+                "type": "Pattern",
+                "elements": [
+                    {
+                        "type": "TextElement",
+                        "value": "Value"
+                    }
+                ]
+            },
+            "attributes": [
+                {
+                    "type": "Attribute",
+                    "id": {
+                        "type": "Identifier",
+                        "name": "attr1"
+                    },
+                    "value": {
+                        "type": "Pattern",
+                        "elements": [
+                            {
+                                "type": "TextElement",
+                                "value": "Attribute 1"
+                            }
+                        ]
+                    }
+                }
+            ],
+            "comment": null
+        },
+        {
+            "type": "Message",
+            "id": {
+                "type": "Identifier",
+                "name": "extra-whitespace"
+            },
+            "value": {
+                "type": "Pattern",
+                "elements": [
+                    {
+                        "type": "TextElement",
+                        "value": "Value"
+                    }
+                ]
+            },
+            "attributes": [
+                {
+                    "type": "Attribute",
+                    "id": {
+                        "type": "Identifier",
+                        "name": "attr1"
+                    },
+                    "value": {
+                        "type": "Pattern",
+                        "elements": [
+                            {
+                                "type": "TextElement",
+                                "value": "Attribute 1"
+                            }
+                        ]
+                    }
+                }
+            ],
+            "comment": null
+        },
+        {
+            "type": "Message",
+            "id": {
+                "type": "Identifier",
                 "name": "key06"
             },
             "value": {

--- a/fluent.syntax/tests/syntax/fixtures_reference/select_expressions.ftl
+++ b/fluent.syntax/tests/syntax/fixtures_reference/select_expressions.ftl
@@ -22,13 +22,13 @@ invalid-selector-term-variant =
     }
 
 # ERROR Nested expressions are not valid selectors
-invalid-selector-select-expression =
+invalid-selector-nested-expression =
     { { 3 } ->
         *[key] default
     }
 
 # ERROR Select expressions are not valid selectors
-invalid-selector-nested-expression =
+invalid-selector-select-expression =
     { { $sel ->
         *[key] value
         } ->
@@ -37,6 +37,11 @@ invalid-selector-nested-expression =
 
 empty-variant =
     { $sel ->
+       *[key] {""}
+    }
+
+reduced-whitespace =
+    {FOO()->
        *[key] {""}
     }
 

--- a/fluent.syntax/tests/syntax/fixtures_reference/select_expressions.json
+++ b/fluent.syntax/tests/syntax/fixtures_reference/select_expressions.json
@@ -152,7 +152,7 @@
         {
             "type": "Junk",
             "annotations": [],
-            "content": "invalid-selector-select-expression =\n    { { 3 } ->\n        *[key] default\n    }\n\n"
+            "content": "invalid-selector-nested-expression =\n    { { 3 } ->\n        *[key] default\n    }\n\n"
         },
         {
             "type": "Comment",
@@ -161,7 +161,7 @@
         {
             "type": "Junk",
             "annotations": [],
-            "content": "invalid-selector-nested-expression =\n    { { $sel ->\n        *[key] value\n        } ->\n        *[key] default\n    }\n\n"
+            "content": "invalid-selector-select-expression =\n    { { $sel ->\n        *[key] value\n        } ->\n        *[key] default\n    }\n\n"
         },
         {
             "type": "Message",
@@ -181,6 +181,60 @@
                                 "id": {
                                     "type": "Identifier",
                                     "name": "sel"
+                                }
+                            },
+                            "variants": [
+                                {
+                                    "type": "Variant",
+                                    "key": {
+                                        "type": "Identifier",
+                                        "name": "key"
+                                    },
+                                    "value": {
+                                        "type": "Pattern",
+                                        "elements": [
+                                            {
+                                                "type": "Placeable",
+                                                "expression": {
+                                                    "value": "",
+                                                    "type": "StringLiteral"
+                                                }
+                                            }
+                                        ]
+                                    },
+                                    "default": true
+                                }
+                            ]
+                        }
+                    }
+                ]
+            },
+            "attributes": [],
+            "comment": null
+        },
+        {
+            "type": "Message",
+            "id": {
+                "type": "Identifier",
+                "name": "reduced-whitespace"
+            },
+            "value": {
+                "type": "Pattern",
+                "elements": [
+                    {
+                        "type": "Placeable",
+                        "expression": {
+                            "type": "SelectExpression",
+                            "selector": {
+                                "type": "FunctionReference",
+                                "id": {
+                                    "type": "Identifier",
+                                    "name": "FOO"
+                                },
+                                "arguments": {
+                                    "type": "CallArguments",
+                                    "positional": [],
+                                    "named": []
                                 }
                             },
                             "variants": [

--- a/fluent.syntax/tests/syntax/fixtures_reference/select_indent.ftl
+++ b/fluent.syntax/tests/syntax/fixtures_reference/select_indent.ftl
@@ -15,6 +15,7 @@ select-1tbs-indent = {
 select-allman-inline =
 { $selector ->
    *[key] Value
+    [other] Other
 }
 
 select-allman-newline =

--- a/fluent.syntax/tests/syntax/fixtures_reference/select_indent.json
+++ b/fluent.syntax/tests/syntax/fixtures_reference/select_indent.json
@@ -176,6 +176,23 @@
                                         ]
                                     },
                                     "default": true
+                                },
+                                {
+                                    "type": "Variant",
+                                    "key": {
+                                        "type": "Identifier",
+                                        "name": "other"
+                                    },
+                                    "value": {
+                                        "type": "Pattern",
+                                        "elements": [
+                                            {
+                                                "type": "TextElement",
+                                                "value": "Other"
+                                            }
+                                        ]
+                                    },
+                                    "default": false
                                 }
                             ]
                         }

--- a/fluent.syntax/tests/syntax/fixtures_reference/term_parameters.ftl
+++ b/fluent.syntax/tests/syntax/fixtures_reference/term_parameters.ftl
@@ -3,6 +3,6 @@
 }
 
 key01 = { -term }
-key02 = { -term() }
+key02 = { -term () }
 key03 = { -term(arg: 1) }
 key04 = { -term("positional", narg1: 1, narg2: 2) }

--- a/fluent.syntax/tests/syntax/fixtures_reference/terms.ftl
+++ b/fluent.syntax/tests/syntax/fixtures_reference/terms.ftl
@@ -21,3 +21,9 @@
 
 # JUNK Missing =
 -term07
+
+-term08=Value
+    .attr=Attribute
+
+-term09   =  Value
+    .attr  =   Attribute

--- a/fluent.syntax/tests/syntax/fixtures_reference/terms.json
+++ b/fluent.syntax/tests/syntax/fixtures_reference/terms.json
@@ -100,7 +100,77 @@
         {
             "type": "Junk",
             "annotations": [],
-            "content": "-term07\n"
+            "content": "-term07\n\n"
+        },
+        {
+            "type": "Term",
+            "id": {
+                "type": "Identifier",
+                "name": "term08"
+            },
+            "value": {
+                "type": "Pattern",
+                "elements": [
+                    {
+                        "type": "TextElement",
+                        "value": "Value"
+                    }
+                ]
+            },
+            "attributes": [
+                {
+                    "type": "Attribute",
+                    "id": {
+                        "type": "Identifier",
+                        "name": "attr"
+                    },
+                    "value": {
+                        "type": "Pattern",
+                        "elements": [
+                            {
+                                "type": "TextElement",
+                                "value": "Attribute"
+                            }
+                        ]
+                    }
+                }
+            ],
+            "comment": null
+        },
+        {
+            "type": "Term",
+            "id": {
+                "type": "Identifier",
+                "name": "term09"
+            },
+            "value": {
+                "type": "Pattern",
+                "elements": [
+                    {
+                        "type": "TextElement",
+                        "value": "Value"
+                    }
+                ]
+            },
+            "attributes": [
+                {
+                    "type": "Attribute",
+                    "id": {
+                        "type": "Identifier",
+                        "name": "attr"
+                    },
+                    "value": {
+                        "type": "Pattern",
+                        "elements": [
+                            {
+                                "type": "TextElement",
+                                "value": "Attribute"
+                            }
+                        ]
+                    }
+                }
+            ],
+            "comment": null
         }
     ]
 }

--- a/fluent.syntax/tests/syntax/fixtures_reference/zero_length.json
+++ b/fluent.syntax/tests/syntax/fixtures_reference/zero_length.json
@@ -1,0 +1,4 @@
+{
+    "type": "Resource",
+    "body": []
+}


### PR DESCRIPTION
This is picking up the tests for projectfluent/fluent#281,
and adjusts the parser to pass those tests.

This is the port of https://github.com/projectfluent/fluent.js/pull/422.