### PR TITLE
Bundle API and Localization class

### DIFF
--- a/fluent.runtime/CHANGELOG.rst
+++ b/fluent.runtime/CHANGELOG.rst
@@ -8,6 +8,7 @@ fluent.runtime next
   ``fluent.runtime.FluentBundle.add_resource``.
 * Removed ``fluent.runtime.FluentBundle.add_messages``.
 * Replaced ``bundle.format()`` with ``bundle.format_pattern(bundle.get_message().value)``.
+* Added ``fluent.runtime.FluentLocalization`` as main entrypoint for applications.
 
 fluent.runtime 0.2 (September 10, 2019)
 ---------------------------------------

--- a/fluent.runtime/CHANGELOG.rst
+++ b/fluent.runtime/CHANGELOG.rst
@@ -1,6 +1,13 @@
 Changelog
 =========
 
+fluent.runtime next
+-------------------
+
+* Added ``fluent.runtime.FluentResource`` and
+  ``fluent.runtime.FluentBundle.add_resource``.
+* Removed ``fluent.runtime.FluentBundle.add_messages``.
+
 fluent.runtime 0.2 (September 10, 2019)
 ---------------------------------------
 

--- a/fluent.runtime/CHANGELOG.rst
+++ b/fluent.runtime/CHANGELOG.rst
@@ -7,6 +7,7 @@ fluent.runtime next
 * Added ``fluent.runtime.FluentResource`` and
   ``fluent.runtime.FluentBundle.add_resource``.
 * Removed ``fluent.runtime.FluentBundle.add_messages``.
+* Replaced ``bundle.format()`` with ``bundle.format_pattern(bundle.get_message().value)``.
 
 fluent.runtime 0.2 (September 10, 2019)
 ---------------------------------------

--- a/fluent.runtime/CHANGELOG.rst
+++ b/fluent.runtime/CHANGELOG.rst
@@ -4,6 +4,9 @@ Changelog
 fluent.runtime next
 -------------------
 
+fluent.runtime 0.3 (October 23, 2019)
+---------------------------------------
+
 * Added ``fluent.runtime.FluentResource`` and
   ``fluent.runtime.FluentBundle.add_resource``.
 * Removed ``fluent.runtime.FluentBundle.add_messages``.

--- a/fluent.runtime/docs/conf.py
+++ b/fluent.runtime/docs/conf.py
@@ -24,9 +24,9 @@ copyright = '2019, Luke Plant'
 author = 'Luke Plant'
 
 # The short X.Y version
-version = '0.1'
+version = '0.3'
 # The full version, including alpha/beta/rc tags
-release = '0.1'
+release = '0.3'
 
 
 # -- General configuration ---------------------------------------------------

--- a/fluent.runtime/docs/index.rst
+++ b/fluent.runtime/docs/index.rst
@@ -15,4 +15,5 @@ significant changes.
 
    installation
    usage
+   internals
    history

--- a/fluent.runtime/docs/internals.rst
+++ b/fluent.runtime/docs/internals.rst
@@ -1,0 +1,139 @@
+Internals of fluent.runtime
+===========================
+
+The application-facing API for ``fluent.runtime`` is ``FluentLocalization``.
+This is the binding providing basic functionality for using Fluent in a
+project. ``FluentLocalization`` builds on top of ``FluentBundle`` on top of
+``FluentResource``.
+
+``FluentLocalization`` handles
+
+* Basic binding as an application-level API
+* Language fallback
+* uses resource loaders like ``FluentResourceLoader`` to create ``FluentResource``
+
+``FluentBundle`` handles
+
+* Internationalization with plurals, number formatting, and date formatting
+* Aggregating multiple Fluent resources with message and term references
+* Functions exposed to Select and Call Expressions
+
+``FluentResource`` handles parsing of Fluent syntax.
+
+Determining which language to use, and which languages to fall back to is
+outside of the scope of the ``fluent.runtime`` package. A concrete
+application stack might have functionality for that. Otherwise it needs to
+be built, `Babel <http://babel.pocoo.org/en/latest/>`_ has
+`helpers <http://babel.pocoo.org/en/latest/api/core.html#babel.core.negotiate_locale>`_
+for that. ``fluent.runtime`` uses Babel internally for the international
+functionality.
+
+
+These bindings benefit from being adapted to the stack. Say,
+a Django project would configure the localization binding through 
+``django.conf.settings``, and load Fluent files from the installed apps.
+
+Subclassing FluentLocalization
+------------------------------
+
+In the :doc:`usage` documentation, we used ``DemoLocalization``, which we'll
+use here to exemplify how to subclass ``FluentLocalization`` for the needs
+of specific stacks.
+
+.. code-block:: python
+
+  from fluent.runtime import FluentLocalization, FluentResource
+  class DemoLocalization(FluentLocalization):
+    def __init__(self, fluent_content, locale='en', functions=None):
+      # Call super() with one locale, no resources nor loader
+      super(DemoLocalization, self).__init__([locale], [], None, functions=functions)
+      self.resource = FluentResource(fluent_content)
+
+This set up the custom class, passing ``locale`` and ``functions`` to the
+base implementation. What's left to do is to customize the resource loading.
+
+.. code-block:: python
+
+    def _bundles(self):
+      bundle = self._create_bundle(self.locales)
+      bundle.add_resource(self.resource)
+      yield bundle
+
+That's all that we need for our demo purposes.
+
+Using FluentBundle
+------------------
+
+The actual interaction with Fluent content is implemented in ``FluentBundle``.
+Optimizations between the parsed content in ``FluentResource`` and a
+representation suitable for the resolving of Patterns is also handled inside
+``FluentBundle``.
+
+.. code-block:: python
+
+    >>> from fluent.runtime import FluentBundle, FluentResource
+
+You pass a list of locales to the constructor - the first being the
+desired locale, with fallbacks after that:
+
+.. code-block:: python
+
+    >>> bundle = FluentBundle(["en-US"])
+
+The passed locales are used for internationalization purposes inside Fluent,
+being plural forms, as well as formatting of values. The locales passed in
+don't affect the loaded messages, handling multiple localizations and the
+fallback from one to the other is done in the ``FluentLocalization`` class.
+
+You must then add messages. These would normally come from a ``.ftl``
+file stored on disk, here we will just add them directly:
+
+.. code-block:: python
+
+    >>> resource = FluentResource("""
+    ... welcome = Welcome to this great app!
+    ... greet-by-name = Hello, { $name }!
+    ... """)
+    >>> bundle.add_resource(resource)
+
+To generate translations, use the ``get_message`` method to retrieve
+a message from the bundle. This returns an object with ``value`` and
+``attributes`` properties. The ``value`` can be ``None`` or an abstract pattern.
+``attributes`` is a dictionary mapping attribute names to abstract patterns.
+If the the message ID is not found, a ``LookupError`` is raised. An abstract
+pattern is an implementation-dependent representation of a Pattern in the
+Fluent syntax. Then use the ``format_pattern`` method, passing the message value
+or one of its attributes and an optional dictionary of substitution parameters.
+You should only pass patterns to ``format_pattern`` that you got from that same
+bundle. As per the Fluent philosophy, the implementation tries hard to recover
+from any formatting errors and generate the most human readable representation
+of the value. The ``format_pattern`` method thereforereturns a tuple containing
+``(translated string, errors)``, as below.
+
+.. code-block:: python
+
+    >>> welcome = bundle.get_message('welcome')
+    >>> translated, errs = bundle.format_pattern(welcome.value)
+    >>> translated
+    "Welcome to this great app!"
+    >>> errs
+    []
+
+    >>> greet = bundle.get_message('greet-by-name')
+    >>> translated, errs = bundle.format_pattern(greet.value, {'name': 'Jane'})
+    >>> translated
+    'Hello, \u2068Jane\u2069!'
+
+    >>> translated, errs = bundle.format_pattern(greet.value, {})
+    >>> translated
+    'Hello, \u2068{$name}\u2069!'
+    >>> errs
+    [FluentReferenceError('Unknown external: name')]
+
+You will notice the extra characters ``\u2068`` and ``\u2069`` in the
+output. These are Unicode bidi isolation characters that help to ensure
+that the interpolated strings are handled correctly in the situation
+where the text direction of the substitution might not match the text
+direction of the localized text. These characters can be disabled if you
+are sure that is not possible for your app by passing
+``use_isolating=False`` to the ``FluentBundle`` constructor.

--- a/fluent.runtime/docs/requirements.txt
+++ b/fluent.runtime/docs/requirements.txt
@@ -1,0 +1,1 @@
+fluent.pygments

--- a/fluent.runtime/docs/usage.rst
+++ b/fluent.runtime/docs/usage.rst
@@ -45,31 +45,34 @@ file stored on disk, here we will just add them directly:
     ... welcome = Welcome to this great app!
     ... greet-by-name = Hello, { $name }!
     ... """)
-    >>> bundle.add_resource(resource
+    >>> bundle.add_resource(resource)
 
-To generate translations, use the ``format`` method, passing a message
-ID and an optional dictionary of substitution parameters. If the the
-message ID is not found, a ``LookupError`` is raised. Otherwise, as per
-the Fluent philosophy, the implementation tries hard to recover from any
-formatting errors and generate the most human readable representation of
-the value. The ``format`` method therefore returns a tuple containing
-``(translated string, errors)``, as below.
+To generate translations, use the ``get_message`` method to retrieve
+a message from the bundle. If the the message ID is not found, a
+``LookupError`` is raised. Then use the ``format_pattern`` method, passing
+the message value or one if its attributes and an optional dictionary of
+substitution parameters.  As per the Fluent philosophy, the implementation
+tries hard to recover from any formatting errors and generate the most human
+readable representation of the value. The ``format_pattern`` method therefore
+returns a tuple containing ``(translated string, errors)``, as below.
 
 .. code-block:: python
 
-    >>> translated, errs = bundle.format('welcome')
+    >>> welcome = bundle.get_message('welcome')
+    >>> translated, errs = bundle.format_pattern(welcome.value)
     >>> translated
     "Welcome to this great app!"
     >>> errs
     []
 
-    >>> translated, errs = bundle.format('greet-by-name', {'name': 'Jane'})
+    >>> greet = bundle.get_message('greet-by-name')
+    >>> translated, errs = bundle.format_pattern(greet.value, {'name': 'Jane'})
     >>> translated
     'Hello, \u2068Jane\u2069!'
 
-    >>> translated, errs = bundle.format('greet-by-name', {})
+    >>> translated, errs = bundle.format_pattern(greet.value, {})
     >>> translated
-    'Hello, \u2068name\u2069!'
+    'Hello, \u2068{$name}\u2069!'
     >>> errs
     [FluentReferenceError('Unknown external: name')]
 
@@ -105,7 +108,8 @@ When rendering translations, Fluent passes any numeric arguments (``int``,
     >>> bundle.add_resource(FluentResource(
     ... "show-total-points = You have { $points } points."
     ... ))
-    >>> val, errs = bundle.format("show-total-points", {'points': 1234567})
+    >>> total_points = bundle.get_message("show-total-points")
+    >>> val, errs = bundle.format_pattern(total_points.value, {'points': 1234567})
     >>> val
     'You have 1,234,567 points.'
 
@@ -117,14 +121,15 @@ by wrapping your numeric arguments with
 
     >>> from fluent.runtime.types import fluent_number
     >>> points = fluent_number(1234567, useGrouping=False)
-    >>> bundle.format("show-total-points", {'points': points})[0]
+    >>> val, errs = bundle.format_pattern(total_points.value, {'points': points})[0]
     'You have 1234567 points.'
 
     >>> amount = fluent_number(1234.56, style="currency", currency="USD")
     >>> bundle.add_resource(FluentResource(
     ... "your-balance = Your balance is { $amount }"
     ... ))
-    >>> bundle.format("your-balance", {'amount': amount})[0]
+    >>> balance = bundle.get_message("your-balance")
+    >>> bundle.format_pattern(balance.value, {'amount': amount})[0]
     'Your balance is $1,234.56'
 
 The options available are defined in the Fluent spec for
@@ -142,7 +147,8 @@ passed through locale aware functions:
 
     >>> from datetime import date
     >>> bundle.add_resource(FluentResource("today-is = Today is { $today }"))
-    >>> val, errs = bundle.format("today-is", {"today": date.today() })
+    >>> today_is = bundle.get_message("today-is")
+    >>> val, errs = bundle.format(today_is.value, {"today": date.today() })
     >>> val
     'Today is Jun 16, 2018'
 
@@ -171,7 +177,7 @@ To specify options from Python code, use
     >>> from fluent.runtime.types import fluent_date
     >>> today = date.today()
     >>> short_today = fluent_date(today, dateStyle='short')
-    >>> val, errs = bundle.format("today-is", {"today": short_today })
+    >>> val, errs = bundle.format_pattern(today_is, {"today": short_today })
     >>> val
     'Today is 6/17/18'
 
@@ -201,7 +207,8 @@ ways:
        datetime.datetime(2018, 6, 17, 12, 15, 5, 677597)
 
        >>> bundle.add_resource(FluentResource("now-is = Now is { $now }"))
-       >>> val, errs = bundle.format("now-is",
+       >>> now_is = bundle.get_message("now-is")
+       >>> val, errs = bundle.format_pattern(now_is.value,
        ...    {"now": fluent_date(utcnow,
        ...                        timeZone="Europe/Moscow",
        ...                        dateStyle="medium",
@@ -233,7 +240,7 @@ You can add functions to the ones available to FTL authors by passing a
     ...   *[other]    Welcome
     ...   }
     ... """))
-    >>> print(bundle.format('welcome')[0]
+    >>> print(bundle.format_pattern(bundle.get_message('welcome'))[0])
     Welcome to Linux
 
 These functions can accept positional and keyword arguments (like the

--- a/fluent.runtime/docs/usage.rst
+++ b/fluent.runtime/docs/usage.rst
@@ -27,7 +27,7 @@ Once you have some FTL files, you can generate translations using the
 
 .. code-block:: python
 
-    >>> from fluent.runtime import FluentBundle
+    >>> from fluent.runtime import FluentBundle, FluentResource
 
 You pass a list of locales to the constructor - the first being the
 desired locale, with fallbacks after that:
@@ -41,10 +41,11 @@ file stored on disk, here we will just add them directly:
 
 .. code-block:: python
 
-    >>> bundle.add_messages("""
+    >>> resource = FluentResource("""
     ... welcome = Welcome to this great app!
     ... greet-by-name = Hello, { $name }!
     ... """)
+    >>> bundle.add_resource(resource
 
 To generate translations, use the ``format`` method, passing a message
 ID and an optional dictionary of substitution parameters. If the the
@@ -101,7 +102,9 @@ When rendering translations, Fluent passes any numeric arguments (``int``,
 
 .. code-block:: python
 
-    >>> bundle.add_messages("show-total-points = You have { $points } points.")
+    >>> bundle.add_resource(FluentResource(
+    ... "show-total-points = You have { $points } points."
+    ... ))
     >>> val, errs = bundle.format("show-total-points", {'points': 1234567})
     >>> val
     'You have 1,234,567 points.'
@@ -118,7 +121,9 @@ by wrapping your numeric arguments with
     'You have 1234567 points.'
 
     >>> amount = fluent_number(1234.56, style="currency", currency="USD")
-    >>> bundle.add_messages("your-balance = Your balance is { $amount }")
+    >>> bundle.add_resource(FluentResource(
+    ... "your-balance = Your balance is { $amount }"
+    ... ))
     >>> bundle.format("your-balance", {'amount': amount})[0]
     'Your balance is $1,234.56'
 
@@ -136,7 +141,7 @@ passed through locale aware functions:
 .. code-block:: python
 
     >>> from datetime import date
-    >>> bundle.add_messages("today-is = Today is { $today }")
+    >>> bundle.add_resource(FluentResource("today-is = Today is { $today }"))
     >>> val, errs = bundle.format("today-is", {"today": date.today() })
     >>> val
     'Today is Jun 16, 2018'
@@ -145,7 +150,9 @@ You can explicitly call the ``DATETIME`` builtin to specify options:
 
 .. code-block:: python
 
-    >>> bundle.add_messages('today-is = Today is { DATETIME($today, dateStyle: "short") }')
+    >>> bundle.add_resource(FluentResource(
+    ... 'today-is = Today is { DATETIME($today, dateStyle: "short") }'
+    ... ))
 
 See the `DATETIME
 docs <https://projectfluent.org/fluent/guide/functions.html#datetime>`_.
@@ -193,7 +200,7 @@ ways:
        >>> utcnow
        datetime.datetime(2018, 6, 17, 12, 15, 5, 677597)
 
-       >>> bundle.add_messages("now-is = Now is { $now }")
+       >>> bundle.add_resource(FluentResource("now-is = Now is { $now }"))
        >>> val, errs = bundle.format("now-is",
        ...    {"now": fluent_date(utcnow,
        ...                        timeZone="Europe/Moscow",
@@ -218,14 +225,14 @@ You can add functions to the ones available to FTL authors by passing a
     ...            'Windows': 'windows'}.get(platform.system(), 'other')
 
     >>> bundle = FluentBundle(['en-US'], functions={'OS': os_name})
-    >>> bundle.add_messages("""
+    >>> bundle.add_resource(FluentResource("""
     ... welcome = { OS() ->
     ...    [linux]    Welcome to Linux
     ...    [mac]      Welcome to Mac
     ...    [windows]  Welcome to Windows
     ...   *[other]    Welcome
     ...   }
-    ... """)
+    ... """))
     >>> print(bundle.format('welcome')[0]
     Welcome to Linux
 

--- a/fluent.runtime/docs/usage.rst
+++ b/fluent.runtime/docs/usage.rst
@@ -19,70 +19,66 @@ In order to use fluent.runtime, you will need to create FTL files. `Read the
 Fluent Syntax Guide <http://projectfluent.org/fluent/guide/>`_ in order to
 learn more about the syntax.
 
-Using FluentBundle
-------------------
+Using FluentLocalization
+------------------------
 
 Once you have some FTL files, you can generate translations using the
-``fluent.runtime`` package. You start with the ``FluentBundle`` class:
+``fluent.runtime`` package. You start with the ``FluentLocalization`` class:
 
 .. code-block:: python
 
-    >>> from fluent.runtime import FluentBundle, FluentResource
+    >>> from fluent.runtime import FluentLocalization, FluentResourceLoader
 
+The Fluent files of your application are loaded with a ``FluentResourceLoader``.
+
+.. code-block:: python
+
+    >>> loader = FluentResourceLoader("l10n/{locale}")
+
+The main entrypoint for your application is a ``FluentLocalization``.
 You pass a list of locales to the constructor - the first being the
-desired locale, with fallbacks after that:
+desired locale, with fallbacks after that - as well as resource IDs and your
+loader.
 
 .. code-block:: python
 
-    >>> bundle = FluentBundle(["en-US"])
+    >>> l10n = FluentLocalization(["de", "en-US"], ["main.ftl"], loader)
+    >>> val = l10n.format_value("my-first-string")
+    "Fluent can be easy"
 
-You must then add messages. These would normally come from a ``.ftl``
-file stored on disk, here we will just add them directly:
+This assumes that you have a directory layout like so
+
+.. code-block::
+
+    l10n/
+      de/
+        main.ftl
+      en-US/
+        main.ftl
+
+and ``l10n/de/main.ftl`` with:
+
+.. code-block:: fluent
+
+  second-string = Eine Übersetzung
+
+as well as ``l10n/en-US/main.ftl`` with:
+
+.. code-block:: fluent
+
+  my-first-string = Fluent can be easy
+  second-string = An original string
+
+As you can see, our first example returned the English string, as that's on
+our fallback list. When retrieving an existing translation, you get the
+translated results as expected:
 
 .. code-block:: python
 
-    >>> resource = FluentResource("""
-    ... welcome = Welcome to this great app!
-    ... greet-by-name = Hello, { $name }!
-    ... """)
-    >>> bundle.add_resource(resource)
+  >>> l10n.format_value("second-string")
+  "Eine Übersetzung"
 
-To generate translations, use the ``get_message`` method to retrieve
-a message from the bundle. If the the message ID is not found, a
-``LookupError`` is raised. Then use the ``format_pattern`` method, passing
-the message value or one if its attributes and an optional dictionary of
-substitution parameters.  As per the Fluent philosophy, the implementation
-tries hard to recover from any formatting errors and generate the most human
-readable representation of the value. The ``format_pattern`` method therefore
-returns a tuple containing ``(translated string, errors)``, as below.
 
-.. code-block:: python
-
-    >>> welcome = bundle.get_message('welcome')
-    >>> translated, errs = bundle.format_pattern(welcome.value)
-    >>> translated
-    "Welcome to this great app!"
-    >>> errs
-    []
-
-    >>> greet = bundle.get_message('greet-by-name')
-    >>> translated, errs = bundle.format_pattern(greet.value, {'name': 'Jane'})
-    >>> translated
-    'Hello, \u2068Jane\u2069!'
-
-    >>> translated, errs = bundle.format_pattern(greet.value, {})
-    >>> translated
-    'Hello, \u2068{$name}\u2069!'
-    >>> errs
-    [FluentReferenceError('Unknown external: name')]
-
-You will notice the extra characters ``\u2068`` and ``\u2069`` in the
-output. These are Unicode bidi isolation characters that help to ensure
-that the interpolated strings are handled correctly in the situation
-where the text direction of the substitution might not match the text
-direction of the localized text. These characters can be disabled if you
-are sure that is not possible for your app by passing
-``use_isolating=False`` to the ``FluentBundle`` constructor.
 
 Python 2
 ~~~~~~~~
@@ -97,6 +93,18 @@ module or the start of your repl session:
 
     from __future__ import unicode_literals
 
+DemoLocalization
+~~~~~~~~~~~~~~~~
+
+To make the documentation easier to read, we're using a ``DemoLocalization``,
+that just uses a single literal Fluent resource. Find out more about the
+details in the :doc:`internals` section.
+
+.. code-block:: python
+
+  >>> l10n = DemoLocalization("key = A localization")
+  >>> pl = DemoLocalization("key = A localization", locale="pl")
+
 Numbers
 ~~~~~~~
 
@@ -105,11 +113,10 @@ When rendering translations, Fluent passes any numeric arguments (``int``,
 
 .. code-block:: python
 
-    >>> bundle.add_resource(FluentResource(
+    >>> l10n = DemoLocalization(
     ... "show-total-points = You have { $points } points."
-    ... ))
-    >>> total_points = bundle.get_message("show-total-points")
-    >>> val, errs = bundle.format_pattern(total_points.value, {'points': 1234567})
+    ... )
+    >>> val = l10n.format_value("show-total-points", {'points': 1234567})
     >>> val
     'You have 1,234,567 points.'
 
@@ -121,15 +128,14 @@ by wrapping your numeric arguments with
 
     >>> from fluent.runtime.types import fluent_number
     >>> points = fluent_number(1234567, useGrouping=False)
-    >>> val, errs = bundle.format_pattern(total_points.value, {'points': points})[0]
+    >>> l10n.format_value("show-total-points", {'points': 1234567})
     'You have 1234567 points.'
 
     >>> amount = fluent_number(1234.56, style="currency", currency="USD")
-    >>> bundle.add_resource(FluentResource(
+    >>> l10n = DemoLocalization(
     ... "your-balance = Your balance is { $amount }"
-    ... ))
-    >>> balance = bundle.get_message("your-balance")
-    >>> bundle.format_pattern(balance.value, {'amount': amount})[0]
+    ... )
+    >>> l10n.format_value(balance.value, {'amount': amount})
     'Your balance is $1,234.56'
 
 The options available are defined in the Fluent spec for
@@ -137,7 +143,7 @@ The options available are defined in the Fluent spec for
 Some of these options can also be defined in the FTL files, as described
 in the Fluent spec, and the options will be merged.
 
-Date and time
+Date and Time
 ~~~~~~~~~~~~~
 
 Python ``datetime.datetime`` and ``datetime.date`` objects are also
@@ -146,9 +152,8 @@ passed through locale aware functions:
 .. code-block:: python
 
     >>> from datetime import date
-    >>> bundle.add_resource(FluentResource("today-is = Today is { $today }"))
-    >>> today_is = bundle.get_message("today-is")
-    >>> val, errs = bundle.format(today_is.value, {"today": date.today() })
+    >>> l10n = DemoLocalization("today-is = Today is { $today }")
+    >>> val = bundle.format_value("today-is", {"today": date.today() })
     >>> val
     'Today is Jun 16, 2018'
 
@@ -156,9 +161,9 @@ You can explicitly call the ``DATETIME`` builtin to specify options:
 
 .. code-block:: python
 
-    >>> bundle.add_resource(FluentResource(
+    >>> l10n = DemoLocalization(
     ... 'today-is = Today is { DATETIME($today, dateStyle: "short") }'
-    ... ))
+    ... )
 
 See the `DATETIME
 docs <https://projectfluent.org/fluent/guide/functions.html#datetime>`_.
@@ -177,7 +182,7 @@ To specify options from Python code, use
     >>> from fluent.runtime.types import fluent_date
     >>> today = date.today()
     >>> short_today = fluent_date(today, dateStyle='short')
-    >>> val, errs = bundle.format_pattern(today_is, {"today": short_today })
+    >>> val = l10n.format_value("today-is", {"today": short_today })
     >>> val
     'Today is 6/17/18'
 
@@ -206,9 +211,8 @@ ways:
        >>> utcnow
        datetime.datetime(2018, 6, 17, 12, 15, 5, 677597)
 
-       >>> bundle.add_resource(FluentResource("now-is = Now is { $now }"))
-       >>> now_is = bundle.get_message("now-is")
-       >>> val, errs = bundle.format_pattern(now_is.value,
+       >>> l10n = DemoLocalization("now-is = Now is { $now }")
+       >>> val = bundle.format_pattern("now-is",
        ...    {"now": fluent_date(utcnow,
        ...                        timeZone="Europe/Moscow",
        ...                        dateStyle="medium",
@@ -220,7 +224,7 @@ Custom functions
 ~~~~~~~~~~~~~~~~
 
 You can add functions to the ones available to FTL authors by passing a
-``functions`` dictionary to the ``FluentBundle`` constructor:
+``functions`` dictionary to the ``FluentLocalization`` constructor:
 
 .. code-block:: python
 
@@ -231,17 +235,20 @@ You can add functions to the ones available to FTL authors by passing a
     ...            'Darwin': 'mac',
     ...            'Windows': 'windows'}.get(platform.system(), 'other')
 
-    >>> bundle = FluentBundle(['en-US'], functions={'OS': os_name})
-    >>> bundle.add_resource(FluentResource("""
-    ... welcome = { OS() ->
-    ...    [linux]    Welcome to Linux
-    ...    [mac]      Welcome to Mac
-    ...    [windows]  Welcome to Windows
-    ...   *[other]    Welcome
-    ...   }
-    ... """))
-    >>> print(bundle.format_pattern(bundle.get_message('welcome'))[0])
+    >>> l10n = FluentLocalization(['en-US'], ['os.ftl'], loader, functions={'OS': os_name})
+    >>> l10n.format_value('welcome')
     Welcome to Linux
+
+That's with ``l10n/en-US/os.ftl`` as:
+
+.. code-block:: fluent
+
+    welcome = { OS() ->
+       [linux]    Welcome to Linux
+       [mac]      Welcome to Mac
+       [windows]  Welcome to Windows
+      *[other]    Welcome
+      }
 
 These functions can accept positional and keyword arguments (like the
 ``NUMBER`` and ``DATETIME`` builtins), and in this case must accept the

--- a/fluent.runtime/fluent/runtime/__init__.py
+++ b/fluent.runtime/fluent/runtime/__init__.py
@@ -11,6 +11,16 @@ from .builtins import BUILTINS
 from .prepare import Compiler
 from .resolver import ResolverEnvironment, CurrentEnvironment
 from .utils import native_to_fluent
+from .fallback import FluentLocalization, AbstractResourceLoader, FluentResourceLoader
+
+
+__all__ = [
+    'FluentLocalization',
+    'AbstractResourceLoader',
+    'FluentResourceLoader',
+    'FluentResource',
+    'FluentBundle',
+]
 
 
 def FluentResource(source):

--- a/fluent.runtime/fluent/runtime/__init__.py
+++ b/fluent.runtime/fluent/runtime/__init__.py
@@ -13,6 +13,11 @@ from .resolver import ResolverEnvironment, CurrentEnvironment
 from .utils import ATTRIBUTE_SEPARATOR, TERM_SIGIL, ast_to_id, native_to_fluent
 
 
+def FluentResource(source):
+    parser = FluentParser()
+    return parser.parse(source)
+
+
 class FluentBundle(object):
     """
     Message contexts are single-language stores of translations.  They are
@@ -39,14 +44,12 @@ class FluentBundle(object):
         self._babel_locale = self._get_babel_locale()
         self._plural_form = babel.plural.to_python(self._babel_locale.plural_form)
 
-    def add_messages(self, source):
-        parser = FluentParser()
-        resource = parser.parse(source)
+    def add_resource(self, resource, allow_overrides=False):
         # TODO - warn/error about duplicates
         for item in resource.body:
             if isinstance(item, (Message, Term)):
                 full_id = ast_to_id(item)
-                if full_id not in self._messages_and_terms:
+                if full_id not in self._messages_and_terms or allow_overrides:
                     self._messages_and_terms[full_id] = item
 
     def has_message(self, message_id):

--- a/fluent.runtime/fluent/runtime/__init__.py
+++ b/fluent.runtime/fluent/runtime/__init__.py
@@ -10,7 +10,7 @@ from fluent.syntax.ast import Message, Term
 from .builtins import BUILTINS
 from .prepare import Compiler
 from .resolver import ResolverEnvironment, CurrentEnvironment
-from .utils import ATTRIBUTE_SEPARATOR, TERM_SIGIL, ast_to_id, native_to_fluent
+from .utils import native_to_fluent
 
 
 def FluentResource(source):
@@ -20,12 +20,14 @@ def FluentResource(source):
 
 class FluentBundle(object):
     """
-    Message contexts are single-language stores of translations.  They are
-    responsible for parsing translation resources in the Fluent syntax and can
+    Bundles are single-language stores of translations.  They are
+    aggregate parsed Fluent resources in the Fluent syntax and can
     format translation units (entities) to strings.
 
-    Always use `FluentBundle.format` to retrieve translation units from
-    a context.  Translations can contain references to other entities or
+    Always use `FluentBundle.get_message` to retrieve translation units from
+    a bundle. Generate the localized string by using `format_pattern` on
+    `message.value` or `message.attributes['attr']`.
+    Translations can contain references to other entities or
     external arguments, conditional logic in form of select expressions, traits
     which describe their grammatical features, and can use Fluent builtins.
     See the documentation of the Fluent syntax for more information.
@@ -38,7 +40,8 @@ class FluentBundle(object):
             _functions.update(functions)
         self._functions = _functions
         self.use_isolating = use_isolating
-        self._messages_and_terms = {}
+        self._messages = {}
+        self._terms = {}
         self._compiled = {}
         self._compiler = Compiler()
         self._babel_locale = self._get_babel_locale()
@@ -47,30 +50,33 @@ class FluentBundle(object):
     def add_resource(self, resource, allow_overrides=False):
         # TODO - warn/error about duplicates
         for item in resource.body:
-            if isinstance(item, (Message, Term)):
-                full_id = ast_to_id(item)
-                if full_id not in self._messages_and_terms or allow_overrides:
-                    self._messages_and_terms[full_id] = item
+            if not isinstance(item, (Message, Term)):
+                continue
+            map_ = self._messages if isinstance(item, Message) else self._terms
+            full_id = item.id.name
+            if full_id not in map_ or allow_overrides:
+                map_[full_id] = item
 
     def has_message(self, message_id):
-        if message_id.startswith(TERM_SIGIL) or ATTRIBUTE_SEPARATOR in message_id:
-            return False
-        return message_id in self._messages_and_terms
+        return message_id in self._messages
 
-    def lookup(self, full_id):
-        if full_id not in self._compiled:
-            entry_id = full_id.split(ATTRIBUTE_SEPARATOR, 1)[0]
-            entry = self._messages_and_terms[entry_id]
-            compiled = self._compiler(entry)
-            if compiled.value is not None:
-                self._compiled[entry_id] = compiled.value
-            for attr in compiled.attributes:
-                self._compiled[ATTRIBUTE_SEPARATOR.join([entry_id, attr.id.name])] = attr.value
-        return self._compiled[full_id]
+    def get_message(self, message_id):
+        return self._lookup(message_id)
 
-    def format(self, message_id, args=None):
-        if message_id.startswith(TERM_SIGIL):
-            raise LookupError(message_id)
+    def _lookup(self, entry_id, term=False):
+        if term:
+            compiled_id = '-' + entry_id
+        else:
+            compiled_id = entry_id
+        try:
+            return self._compiled[compiled_id]
+        except LookupError:
+            pass
+        entry = self._terms[entry_id] if term else self._messages[entry_id]
+        self._compiled[compiled_id] = self._compiler(entry)
+        return self._compiled[compiled_id]
+
+    def format_pattern(self, pattern, args=None):
         if args is not None:
             fluent_args = {
                 argname: native_to_fluent(argvalue)
@@ -80,12 +86,11 @@ class FluentBundle(object):
             fluent_args = {}
 
         errors = []
-        resolve = self.lookup(message_id)
         env = ResolverEnvironment(context=self,
                                   current=CurrentEnvironment(args=fluent_args),
                                   errors=errors)
         try:
-            result = resolve(env)
+            result = pattern(env)
         except ValueError as e:
             errors.append(e)
             result = '{???}'

--- a/fluent.runtime/fluent/runtime/fallback.py
+++ b/fluent.runtime/fluent/runtime/fallback.py
@@ -1,0 +1,117 @@
+# -*- coding: utf-8 -*-
+
+import codecs
+import os
+import six
+
+
+class FluentLocalization(object):
+    """
+    Generic API for Fluent applications.
+
+    This handles language fallback, bundle creation and string localization.
+    It uses the given resource loader to load and parse Fluent data.
+    """
+    def __init__(
+        self, locales, resource_ids, resource_loader,
+        use_isolating=False,
+        bundle_class=None, functions=None,
+    ):
+        self.locales = locales
+        self.resource_ids = resource_ids
+        self.resource_loader = resource_loader
+        self.use_isolating = use_isolating
+        if bundle_class is None:
+            from fluent.runtime import FluentBundle
+            self.bundle_class = FluentBundle
+        else:
+            self.bundle_class = bundle_class
+        self.functions = functions
+        self._bundle_cache = []
+        self._bundle_it = self._iterate_bundles()
+
+    def format_value(self, msg_id, args=None):
+        for bundle in self._bundles():
+            if not bundle.has_message(msg_id):
+                continue
+            msg = bundle.get_message(msg_id)
+            if not msg.value:
+                continue
+            val, errors = bundle.format_pattern(msg.value, args)
+            return val
+        return msg_id
+
+    def _create_bundle(self, locales):
+        return self.bundle_class(
+            locales, functions=self.functions, use_isolating=self.use_isolating
+        )
+
+    def _bundles(self):
+        bundle_pointer = 0
+        while True:
+            if bundle_pointer == len(self._bundle_cache):
+                try:
+                    self._bundle_cache.append(next(self._bundle_it))
+                except StopIteration:
+                    return
+            yield self._bundle_cache[bundle_pointer]
+            bundle_pointer += 1
+
+    def _iterate_bundles(self):
+        for first_loc in range(0, len(self.locales)):
+            locs = self.locales[first_loc:]
+            for resources in self.resource_loader.resources(locs[0], self.resource_ids):
+                bundle = self._create_bundle(locs)
+                for resource in resources:
+                    bundle.add_resource(resource)
+                yield bundle
+
+
+class AbstractResourceLoader(object):
+    """
+    Interface to implement for resource loaders.
+    """
+    def resources(self, locale, resource_ids):
+        """
+        Yield lists of FluentResource objects, corresponding to
+        each of the resource_ids.
+        If there are multiple locations, this may yield multiple lists.
+        If a resource isn't found in any location, yield a partial list,
+        but don't yield empty lists.
+        """
+        raise NotImplementedError
+
+
+class FluentResourceLoader(AbstractResourceLoader):
+    """
+    Resource loader to read Fluent files from disk.
+
+    Different locales are in different locations based on locale code.
+    The locale code should be encoded as `{locale}` in the roots, or in
+    the resource_ids.
+    This loader does not support loading resources for one bundle from
+    different roots.
+    """
+    def __init__(self, roots):
+        """
+        Create a resource loader. The roots may be a string for a single
+        location on disk, or a list of strings.
+        """
+        self.roots = [roots] if isinstance(roots, six.text_type) else roots
+        from fluent.runtime import FluentResource
+        self.Resource = FluentResource
+
+    def resources(self, locale, resource_ids):
+        for root in self.roots:
+            resources = []
+            for resource_id in resource_ids:
+                path = self.localize_path(os.path.join(root, resource_id), locale)
+                if not os.path.isfile(path):
+                    continue
+                content = codecs.open(path, 'r', 'utf-8').read()
+                resources.append(self.Resource(content))
+            if resources:
+                yield resources
+
+    def localize_path(self, path, locale):
+        return path.format(locale=locale)

--- a/fluent.runtime/fluent/runtime/utils.py
+++ b/fluent.runtime/fluent/runtime/utils.py
@@ -3,22 +3,13 @@ from __future__ import absolute_import, unicode_literals
 from datetime import date, datetime
 from decimal import Decimal
 
-from fluent.syntax.ast import Term, TermReference
+from fluent.syntax.ast import TermReference
 
 from .types import FluentInt, FluentFloat, FluentDecimal, FluentDate, FluentDateTime
 from .errors import FluentReferenceError
 
 TERM_SIGIL = '-'
 ATTRIBUTE_SEPARATOR = '.'
-
-
-def ast_to_id(ast):
-    """
-    Returns a string reference for a Term or Message
-    """
-    if isinstance(ast, Term):
-        return TERM_SIGIL + ast.id.name
-    return ast.id.name
 
 
 def native_to_fluent(val):
@@ -39,7 +30,7 @@ def native_to_fluent(val):
     return val
 
 
-def reference_to_id(ref, ignore_attributes=False):
+def reference_to_id(ref):
     """
     Returns a string reference for a MessageReference or TermReference
     AST node.
@@ -55,7 +46,7 @@ def reference_to_id(ref, ignore_attributes=False):
     else:
         start = ref.id.name
 
-    if not ignore_attributes and ref.attribute:
+    if ref.attribute:
         return ''.join([start, ATTRIBUTE_SEPARATOR, ref.attribute.name])
     return start
 

--- a/fluent.runtime/setup.py
+++ b/fluent.runtime/setup.py
@@ -3,7 +3,7 @@ from setuptools import setup
 
 
 setup(name='fluent.runtime',
-      version='0.2',
+      version='0.3',
       description='Localization library for expressive translations.',
       long_description='See https://github.com/projectfluent/python-fluent/ for more info.',
       author='Luke Plant',

--- a/fluent.runtime/setup.py
+++ b/fluent.runtime/setup.py
@@ -28,4 +28,7 @@ setup(name='fluent.runtime',
           'six',
       ],
       test_suite='tests',
+      tests_require=[
+          'mock',
+      ],
       )

--- a/fluent.runtime/tests/format/test_arguments.py
+++ b/fluent.runtime/tests/format/test_arguments.py
@@ -2,7 +2,7 @@ from __future__ import absolute_import, unicode_literals
 
 import unittest
 
-from fluent.runtime import FluentBundle
+from fluent.runtime import FluentBundle, FluentResource
 
 from ..utils import dedent_ftl
 
@@ -10,7 +10,7 @@ from ..utils import dedent_ftl
 class TestNumbersInValues(unittest.TestCase):
     def setUp(self):
         self.ctx = FluentBundle(['en-US'], use_isolating=False)
-        self.ctx.add_messages(dedent_ftl("""
+        self.ctx.add_resource(FluentResource(dedent_ftl("""
             foo = Foo { $num }
             bar = { foo }
             baz =
@@ -18,7 +18,7 @@ class TestNumbersInValues(unittest.TestCase):
             qux = { "a" ->
                *[a]     Baz Variant A { $num }
              }
-        """))
+        """)))
 
     def test_can_be_used_in_the_message_value(self):
         val, errs = self.ctx.format('foo', {'num': 3})
@@ -44,9 +44,9 @@ class TestNumbersInValues(unittest.TestCase):
 class TestStrings(unittest.TestCase):
     def setUp(self):
         self.ctx = FluentBundle(['en-US'], use_isolating=False)
-        self.ctx.add_messages(dedent_ftl("""
+        self.ctx.add_resource(FluentResource(dedent_ftl("""
             foo = { $arg }
-        """))
+        """)))
 
     def test_can_be_a_string(self):
         val, errs = self.ctx.format('foo', {'arg': 'Argument'})

--- a/fluent.runtime/tests/format/test_arguments.py
+++ b/fluent.runtime/tests/format/test_arguments.py
@@ -9,8 +9,8 @@ from ..utils import dedent_ftl
 
 class TestNumbersInValues(unittest.TestCase):
     def setUp(self):
-        self.ctx = FluentBundle(['en-US'], use_isolating=False)
-        self.ctx.add_resource(FluentResource(dedent_ftl("""
+        self.bundle = FluentBundle(['en-US'], use_isolating=False)
+        self.bundle.add_resource(FluentResource(dedent_ftl("""
             foo = Foo { $num }
             bar = { foo }
             baz =
@@ -21,34 +21,34 @@ class TestNumbersInValues(unittest.TestCase):
         """)))
 
     def test_can_be_used_in_the_message_value(self):
-        val, errs = self.ctx.format('foo', {'num': 3})
+        val, errs = self.bundle.format_pattern(self.bundle.get_message('foo').value, {'num': 3})
         self.assertEqual(val, 'Foo 3')
         self.assertEqual(len(errs), 0)
 
     def test_can_be_used_in_the_message_value_which_is_referenced(self):
-        val, errs = self.ctx.format('bar', {'num': 3})
+        val, errs = self.bundle.format_pattern(self.bundle.get_message('bar').value, {'num': 3})
         self.assertEqual(val, 'Foo 3')
         self.assertEqual(len(errs), 0)
 
     def test_can_be_used_in_an_attribute(self):
-        val, errs = self.ctx.format('baz.attr', {'num': 3})
+        val, errs = self.bundle.format_pattern(self.bundle.get_message('baz').attributes['attr'], {'num': 3})
         self.assertEqual(val, 'Baz Attribute 3')
         self.assertEqual(len(errs), 0)
 
     def test_can_be_used_in_a_variant(self):
-        val, errs = self.ctx.format('qux', {'num': 3})
+        val, errs = self.bundle.format_pattern(self.bundle.get_message('qux').value, {'num': 3})
         self.assertEqual(val, 'Baz Variant A 3')
         self.assertEqual(len(errs), 0)
 
 
 class TestStrings(unittest.TestCase):
     def setUp(self):
-        self.ctx = FluentBundle(['en-US'], use_isolating=False)
-        self.ctx.add_resource(FluentResource(dedent_ftl("""
+        self.bundle = FluentBundle(['en-US'], use_isolating=False)
+        self.bundle.add_resource(FluentResource(dedent_ftl("""
             foo = { $arg }
         """)))
 
     def test_can_be_a_string(self):
-        val, errs = self.ctx.format('foo', {'arg': 'Argument'})
+        val, errs = self.bundle.format_pattern(self.bundle.get_message('foo').value, {'arg': 'Argument'})
         self.assertEqual(val, 'Argument')
         self.assertEqual(len(errs), 0)

--- a/fluent.runtime/tests/format/test_attributes.py
+++ b/fluent.runtime/tests/format/test_attributes.py
@@ -2,7 +2,7 @@ from __future__ import absolute_import, unicode_literals
 
 import unittest
 
-from fluent.runtime import FluentBundle
+from fluent.runtime import FluentBundle, FluentResource
 from fluent.runtime.errors import FluentReferenceError
 
 from ..utils import dedent_ftl
@@ -12,14 +12,14 @@ class TestAttributesWithStringValues(unittest.TestCase):
 
     def setUp(self):
         self.ctx = FluentBundle(['en-US'], use_isolating=False)
-        self.ctx.add_messages(dedent_ftl("""
+        self.ctx.add_resource(FluentResource(dedent_ftl("""
             foo = Foo
                 .attr = Foo Attribute
             bar = { foo } Bar
                 .attr = Bar Attribute
             ref-foo = { foo.attr }
             ref-bar = { bar.attr }
-        """))
+        """)))
 
     def test_can_be_referenced_for_entities_with_string_values(self):
         val, errs = self.ctx.format('ref-foo', {})
@@ -46,7 +46,7 @@ class TestAttributesWithSimplePatternValues(unittest.TestCase):
 
     def setUp(self):
         self.ctx = FluentBundle(['en-US'], use_isolating=False)
-        self.ctx.add_messages(dedent_ftl("""
+        self.ctx.add_resource(FluentResource(dedent_ftl("""
             foo = Foo
             bar = Bar
                 .attr = { foo } Attribute
@@ -57,7 +57,7 @@ class TestAttributesWithSimplePatternValues(unittest.TestCase):
             ref-bar = { bar.attr }
             ref-baz = { baz.attr }
             ref-qux = { qux.attr }
-        """))
+        """)))
 
     def test_can_be_referenced_for_entities_with_string_values(self):
         val, errs = self.ctx.format('ref-bar', {})
@@ -93,7 +93,7 @@ class TestAttributesWithSimplePatternValues(unittest.TestCase):
 class TestMissing(unittest.TestCase):
     def setUp(self):
         self.ctx = FluentBundle(['en-US'], use_isolating=False)
-        self.ctx.add_messages(dedent_ftl("""
+        self.ctx.add_resource(FluentResource(dedent_ftl("""
             foo = Foo
             bar = Bar
                 .attr = Bar Attribute
@@ -107,7 +107,7 @@ class TestMissing(unittest.TestCase):
             attr-only =
                      .attr  = Attr Only Attribute
             ref-double-missing = { missing.attr }
-        """))
+        """)))
 
     def test_falls_back_for_msg_with_string_value_and_no_attributes(self):
         val, errs = self.ctx.format('ref-foo', {})

--- a/fluent.runtime/tests/format/test_attributes.py
+++ b/fluent.runtime/tests/format/test_attributes.py
@@ -11,8 +11,8 @@ from ..utils import dedent_ftl
 class TestAttributesWithStringValues(unittest.TestCase):
 
     def setUp(self):
-        self.ctx = FluentBundle(['en-US'], use_isolating=False)
-        self.ctx.add_resource(FluentResource(dedent_ftl("""
+        self.bundle = FluentBundle(['en-US'], use_isolating=False)
+        self.bundle.add_resource(FluentResource(dedent_ftl("""
             foo = Foo
                 .attr = Foo Attribute
             bar = { foo } Bar
@@ -22,22 +22,22 @@ class TestAttributesWithStringValues(unittest.TestCase):
         """)))
 
     def test_can_be_referenced_for_entities_with_string_values(self):
-        val, errs = self.ctx.format('ref-foo', {})
+        val, errs = self.bundle.format_pattern(self.bundle.get_message('ref-foo').value, {})
         self.assertEqual(val, 'Foo Attribute')
         self.assertEqual(len(errs), 0)
 
     def test_can_be_referenced_for_entities_with_pattern_values(self):
-        val, errs = self.ctx.format('ref-bar', {})
+        val, errs = self.bundle.format_pattern(self.bundle.get_message('ref-bar').value, {})
         self.assertEqual(val, 'Bar Attribute')
         self.assertEqual(len(errs), 0)
 
     def test_can_be_formatted_directly_for_entities_with_string_values(self):
-        val, errs = self.ctx.format('foo.attr', {})
+        val, errs = self.bundle.format_pattern(self.bundle.get_message('foo').attributes['attr'], {})
         self.assertEqual(val, 'Foo Attribute')
         self.assertEqual(len(errs), 0)
 
     def test_can_be_formatted_directly_for_entities_with_pattern_values(self):
-        val, errs = self.ctx.format('bar.attr', {})
+        val, errs = self.bundle.format_pattern(self.bundle.get_message('bar').attributes['attr'], {})
         self.assertEqual(val, 'Bar Attribute')
         self.assertEqual(len(errs), 0)
 
@@ -45,8 +45,8 @@ class TestAttributesWithStringValues(unittest.TestCase):
 class TestAttributesWithSimplePatternValues(unittest.TestCase):
 
     def setUp(self):
-        self.ctx = FluentBundle(['en-US'], use_isolating=False)
-        self.ctx.add_resource(FluentResource(dedent_ftl("""
+        self.bundle = FluentBundle(['en-US'], use_isolating=False)
+        self.bundle.add_resource(FluentResource(dedent_ftl("""
             foo = Foo
             bar = Bar
                 .attr = { foo } Attribute
@@ -60,40 +60,40 @@ class TestAttributesWithSimplePatternValues(unittest.TestCase):
         """)))
 
     def test_can_be_referenced_for_entities_with_string_values(self):
-        val, errs = self.ctx.format('ref-bar', {})
+        val, errs = self.bundle.format_pattern(self.bundle.get_message('ref-bar').value, {})
         self.assertEqual(val, 'Foo Attribute')
         self.assertEqual(len(errs), 0)
 
     def test_can_be_formatted_directly_for_entities_with_string_values(self):
-        val, errs = self.ctx.format('bar.attr', {})
+        val, errs = self.bundle.format_pattern(self.bundle.get_message('bar').attributes['attr'], {})
         self.assertEqual(val, 'Foo Attribute')
         self.assertEqual(len(errs), 0)
 
     def test_can_be_referenced_for_entities_with_pattern_values(self):
-        val, errs = self.ctx.format('ref-baz', {})
+        val, errs = self.bundle.format_pattern(self.bundle.get_message('ref-baz').value, {})
         self.assertEqual(val, 'Foo Attribute')
         self.assertEqual(len(errs), 0)
 
     def test_can_be_formatted_directly_for_entities_with_pattern_values(self):
-        val, errs = self.ctx.format('baz.attr', {})
+        val, errs = self.bundle.format_pattern(self.bundle.get_message('baz').attributes['attr'], {})
         self.assertEqual(val, 'Foo Attribute')
         self.assertEqual(len(errs), 0)
 
     def test_works_with_self_references(self):
-        val, errs = self.ctx.format('ref-qux', {})
+        val, errs = self.bundle.format_pattern(self.bundle.get_message('ref-qux').value, {})
         self.assertEqual(val, 'Qux Attribute')
         self.assertEqual(len(errs), 0)
 
     def test_works_with_self_references_direct(self):
-        val, errs = self.ctx.format('qux.attr', {})
+        val, errs = self.bundle.format_pattern(self.bundle.get_message('qux').attributes['attr'], {})
         self.assertEqual(val, 'Qux Attribute')
         self.assertEqual(len(errs), 0)
 
 
 class TestMissing(unittest.TestCase):
     def setUp(self):
-        self.ctx = FluentBundle(['en-US'], use_isolating=False)
-        self.ctx.add_resource(FluentResource(dedent_ftl("""
+        self.bundle = FluentBundle(['en-US'], use_isolating=False)
+        self.bundle.add_resource(FluentResource(dedent_ftl("""
             foo = Foo
             bar = Bar
                 .attr = Bar Attribute
@@ -109,47 +109,40 @@ class TestMissing(unittest.TestCase):
             ref-double-missing = { missing.attr }
         """)))
 
-    def test_falls_back_for_msg_with_string_value_and_no_attributes(self):
-        val, errs = self.ctx.format('ref-foo', {})
-        self.assertEqual(val, 'Foo')
+    def test_msg_with_string_value_and_no_attributes(self):
+        val, errs = self.bundle.format_pattern(self.bundle.get_message('ref-foo').value, {})
+        self.assertEqual(val, '{foo.missing}')
         self.assertEqual(errs,
                          [FluentReferenceError(
                              'Unknown attribute: foo.missing')])
 
-    def test_falls_back_for_msg_with_string_value_and_other_attributes(self):
-        val, errs = self.ctx.format('ref-bar', {})
-        self.assertEqual(val, 'Bar')
+    def test_msg_with_string_value_and_other_attributes(self):
+        val, errs = self.bundle.format_pattern(self.bundle.get_message('ref-bar').value, {})
+        self.assertEqual(val, '{bar.missing}')
         self.assertEqual(errs,
                          [FluentReferenceError(
                              'Unknown attribute: bar.missing')])
 
-    def test_falls_back_for_msg_with_pattern_value_and_no_attributes(self):
-        val, errs = self.ctx.format('ref-baz', {})
-        self.assertEqual(val, 'Foo Baz')
+    def test_msg_with_pattern_value_and_no_attributes(self):
+        val, errs = self.bundle.format_pattern(self.bundle.get_message('ref-baz').value, {})
+        self.assertEqual(val, '{baz.missing}')
         self.assertEqual(errs,
                          [FluentReferenceError(
                              'Unknown attribute: baz.missing')])
 
-    def test_falls_back_for_msg_with_pattern_value_and_other_attributes(self):
-        val, errs = self.ctx.format('ref-qux', {})
-        self.assertEqual(val, 'Foo Qux')
+    def test_msg_with_pattern_value_and_other_attributes(self):
+        val, errs = self.bundle.format_pattern(self.bundle.get_message('ref-qux').value, {})
+        self.assertEqual(val, '{qux.missing}')
         self.assertEqual(errs,
                          [FluentReferenceError(
                              'Unknown attribute: qux.missing')])
 
-    def test_attr_only_main(self):
-        # For reference, Javascript implementation returns null for this case.
-        # For Python returning `None` doesn't seem appropriate, since this will
-        # only blow up later if you attempt to add this to a string, so we raise
-        # a LookupError instead, as per entirely missing messages.
-        self.assertRaises(LookupError, self.ctx.format, 'attr-only', {})
-
     def test_attr_only_attribute(self):
-        val, errs = self.ctx.format('attr-only.attr', {})
+        val, errs = self.bundle.format_pattern(self.bundle.get_message('attr-only').attributes['attr'], {})
         self.assertEqual(val, 'Attr Only Attribute')
         self.assertEqual(len(errs), 0)
 
     def test_missing_message_and_attribute(self):
-        val, errs = self.ctx.format('ref-double-missing', {})
-        self.assertEqual(val, 'missing.attr')
+        val, errs = self.bundle.format_pattern(self.bundle.get_message('ref-double-missing').value, {})
+        self.assertEqual(val, '{missing.attr}')
         self.assertEqual(errs, [FluentReferenceError('Unknown attribute: missing.attr')])

--- a/fluent.runtime/tests/format/test_builtins.py
+++ b/fluent.runtime/tests/format/test_builtins.py
@@ -4,7 +4,7 @@ import unittest
 from datetime import date, datetime
 from decimal import Decimal
 
-from fluent.runtime import FluentBundle
+from fluent.runtime import FluentBundle, FluentResource
 from fluent.runtime.errors import FluentReferenceError
 from fluent.runtime.types import fluent_date, fluent_number
 
@@ -15,7 +15,7 @@ class TestNumberBuiltin(unittest.TestCase):
 
     def setUp(self):
         self.ctx = FluentBundle(['en-US'], use_isolating=False)
-        self.ctx.add_messages(dedent_ftl("""
+        self.ctx.add_resource(FluentResource(dedent_ftl("""
             implicit-call    = { 123456 }
             implicit-call2   = { $arg }
             defaults         = { NUMBER(123456) }
@@ -23,7 +23,7 @@ class TestNumberBuiltin(unittest.TestCase):
             currency-style   = { NUMBER(123456, style: "currency", currency: "USD") }
             from-arg         = { NUMBER($arg) }
             merge-params     = { NUMBER($arg, useGrouping: 0) }
-        """))
+        """)))
 
     def test_implicit_call(self):
         val, errs = self.ctx.format('implicit-call', {})
@@ -100,11 +100,11 @@ class TestDatetimeBuiltin(unittest.TestCase):
 
     def setUp(self):
         self.ctx = FluentBundle(['en-US'], use_isolating=False)
-        self.ctx.add_messages(dedent_ftl("""
+        self.ctx.add_resource(FluentResource(dedent_ftl("""
             implicit-call    = { $date }
             explicit-call    = { DATETIME($date) }
             call-with-arg    = { DATETIME($date, dateStyle: "long") }
-        """))
+        """)))
 
     def test_implicit_call_date(self):
         val, errs = self.ctx.format('implicit-call', {'date': date(2018, 2, 1)})

--- a/fluent.runtime/tests/format/test_builtins.py
+++ b/fluent.runtime/tests/format/test_builtins.py
@@ -14,8 +14,8 @@ from ..utils import dedent_ftl
 class TestNumberBuiltin(unittest.TestCase):
 
     def setUp(self):
-        self.ctx = FluentBundle(['en-US'], use_isolating=False)
-        self.ctx.add_resource(FluentResource(dedent_ftl("""
+        self.bundle = FluentBundle(['en-US'], use_isolating=False)
+        self.bundle.add_resource(FluentResource(dedent_ftl("""
             implicit-call    = { 123456 }
             implicit-call2   = { $arg }
             defaults         = { NUMBER(123456) }
@@ -26,57 +26,59 @@ class TestNumberBuiltin(unittest.TestCase):
         """)))
 
     def test_implicit_call(self):
-        val, errs = self.ctx.format('implicit-call', {})
+        val, errs = self.bundle.format_pattern(self.bundle.get_message('implicit-call').value, {})
         self.assertEqual(val, "123,456")
         self.assertEqual(len(errs), 0)
 
     def test_implicit_call2_int(self):
-        val, errs = self.ctx.format('implicit-call2', {'arg': 123456})
+        val, errs = self.bundle.format_pattern(self.bundle.get_message('implicit-call2').value, {'arg': 123456})
         self.assertEqual(val, "123,456")
         self.assertEqual(len(errs), 0)
 
     def test_implicit_call2_float(self):
-        val, errs = self.ctx.format('implicit-call2', {'arg': 123456.0})
+        val, errs = self.bundle.format_pattern(self.bundle.get_message('implicit-call2').value, {'arg': 123456.0})
         self.assertEqual(val, "123,456")
         self.assertEqual(len(errs), 0)
 
     def test_implicit_call2_decimal(self):
-        val, errs = self.ctx.format('implicit-call2', {'arg': Decimal('123456.0')})
+        val, errs = self.bundle.format_pattern(
+            self.bundle.get_message('implicit-call2').value, {'arg': Decimal('123456.0')}
+        )
         self.assertEqual(val, "123,456")
         self.assertEqual(len(errs), 0)
 
     def test_defaults(self):
-        val, errs = self.ctx.format('defaults', {})
+        val, errs = self.bundle.format_pattern(self.bundle.get_message('defaults').value, {})
         self.assertEqual(val, "123,456")
         self.assertEqual(len(errs), 0)
 
     def test_percent_style(self):
-        val, errs = self.ctx.format('percent-style', {})
+        val, errs = self.bundle.format_pattern(self.bundle.get_message('percent-style').value, {})
         self.assertEqual(val, "123%")
         self.assertEqual(len(errs), 0)
 
     def test_currency_style(self):
-        val, errs = self.ctx.format('currency-style', {})
+        val, errs = self.bundle.format_pattern(self.bundle.get_message('currency-style').value, {})
         self.assertEqual(val, "$123,456.00")
         self.assertEqual(len(errs), 0)
 
     def test_from_arg_int(self):
-        val, errs = self.ctx.format('from-arg', {'arg': 123456})
+        val, errs = self.bundle.format_pattern(self.bundle.get_message('from-arg').value, {'arg': 123456})
         self.assertEqual(val, "123,456")
         self.assertEqual(len(errs), 0)
 
     def test_from_arg_float(self):
-        val, errs = self.ctx.format('from-arg', {'arg': 123456.0})
+        val, errs = self.bundle.format_pattern(self.bundle.get_message('from-arg').value, {'arg': 123456.0})
         self.assertEqual(val, "123,456")
         self.assertEqual(len(errs), 0)
 
     def test_from_arg_decimal(self):
-        val, errs = self.ctx.format('from-arg', {'arg': Decimal('123456.0')})
+        val, errs = self.bundle.format_pattern(self.bundle.get_message('from-arg').value, {'arg': Decimal('123456.0')})
         self.assertEqual(val, "123,456")
         self.assertEqual(len(errs), 0)
 
     def test_from_arg_missing(self):
-        val, errs = self.ctx.format('from-arg', {})
+        val, errs = self.bundle.format_pattern(self.bundle.get_message('from-arg').value, {})
         self.assertEqual(val, "arg")
         self.assertEqual(len(errs), 1)
         self.assertEqual(errs,
@@ -84,14 +86,15 @@ class TestNumberBuiltin(unittest.TestCase):
 
     def test_partial_application(self):
         number = fluent_number(123456.78, currency="USD", style="currency")
-        val, errs = self.ctx.format('from-arg', {'arg': number})
+        val, errs = self.bundle.format_pattern(self.bundle.get_message('from-arg').value, {'arg': number})
         self.assertEqual(val, "$123,456.78")
         self.assertEqual(len(errs), 0)
 
     def test_merge_params(self):
         number = fluent_number(123456.78, currency="USD", style="currency")
-        val, errs = self.ctx.format('merge-params',
-                                    {'arg': number})
+        val, errs = self.bundle.format_pattern(
+            self.bundle.get_message('merge-params').value, {'arg': number}
+        )
         self.assertEqual(val, "$123456.78")
         self.assertEqual(len(errs), 0)
 
@@ -99,52 +102,64 @@ class TestNumberBuiltin(unittest.TestCase):
 class TestDatetimeBuiltin(unittest.TestCase):
 
     def setUp(self):
-        self.ctx = FluentBundle(['en-US'], use_isolating=False)
-        self.ctx.add_resource(FluentResource(dedent_ftl("""
+        self.bundle = FluentBundle(['en-US'], use_isolating=False)
+        self.bundle.add_resource(FluentResource(dedent_ftl("""
             implicit-call    = { $date }
             explicit-call    = { DATETIME($date) }
             call-with-arg    = { DATETIME($date, dateStyle: "long") }
         """)))
 
     def test_implicit_call_date(self):
-        val, errs = self.ctx.format('implicit-call', {'date': date(2018, 2, 1)})
+        val, errs = self.bundle.format_pattern(
+            self.bundle.get_message('implicit-call').value, {'date': date(2018, 2, 1)}
+        )
         self.assertEqual(val, "Feb 1, 2018")
         self.assertEqual(len(errs), 0)
 
     def test_implicit_call_datetime(self):
-        val, errs = self.ctx.format('implicit-call', {'date': datetime(2018, 2, 1, 14, 15, 16)})
+        val, errs = self.bundle.format_pattern(
+            self.bundle.get_message('implicit-call').value, {'date': datetime(2018, 2, 1, 14, 15, 16)}
+        )
         self.assertEqual(val, "Feb 1, 2018")
         self.assertEqual(len(errs), 0)
 
     def test_explicit_call_date(self):
-        val, errs = self.ctx.format('explicit-call', {'date': date(2018, 2, 1)})
+        val, errs = self.bundle.format_pattern(
+            self.bundle.get_message('explicit-call').value, {'date': date(2018, 2, 1)}
+        )
         self.assertEqual(val, "Feb 1, 2018")
         self.assertEqual(len(errs), 0)
 
     def test_explicit_call_datetime(self):
-        val, errs = self.ctx.format('explicit-call', {'date': datetime(2018, 2, 1, 14, 15, 16)})
+        val, errs = self.bundle.format_pattern(
+            self.bundle.get_message('explicit-call').value, {'date': datetime(2018, 2, 1, 14, 15, 16)}
+        )
         self.assertEqual(val, "Feb 1, 2018")
         self.assertEqual(len(errs), 0)
 
     def test_explicit_call_date_fluent_date(self):
-        val, errs = self.ctx.format('explicit-call', {'date':
-                                                      fluent_date(
-                                                          date(2018, 2, 1),
-                                                          dateStyle='short')
-                                                      })
+        val, errs = self.bundle.format_pattern(
+            self.bundle.get_message('explicit-call').value,
+            {
+                'date': fluent_date(date(2018, 2, 1), dateStyle='short')
+            }
+        )
         self.assertEqual(val, "2/1/18")
         self.assertEqual(len(errs), 0)
 
     def test_arg(self):
-        val, errs = self.ctx.format('call-with-arg', {'date': date(2018, 2, 1)})
+        val, errs = self.bundle.format_pattern(
+            self.bundle.get_message('call-with-arg').value, {'date': date(2018, 2, 1)}
+        )
         self.assertEqual(val, "February 1, 2018")
         self.assertEqual(len(errs), 0)
 
     def test_arg_overrides_fluent_date(self):
-        val, errs = self.ctx.format('call-with-arg', {'date':
-                                                      fluent_date(
-                                                          date(2018, 2, 1),
-                                                          dateStyle='short')
-                                                      })
+        val, errs = self.bundle.format_pattern(
+            self.bundle.get_message('call-with-arg').value,
+            {
+                'date': fluent_date(date(2018, 2, 1), dateStyle='short')
+            }
+        )
         self.assertEqual(val, "February 1, 2018")
         self.assertEqual(len(errs), 0)

--- a/fluent.runtime/tests/format/test_functions.py
+++ b/fluent.runtime/tests/format/test_functions.py
@@ -2,7 +2,7 @@ from __future__ import absolute_import, unicode_literals
 
 import unittest
 
-from fluent.runtime import FluentBundle
+from fluent.runtime import FluentBundle, FluentResource
 from fluent.runtime.errors import FluentReferenceError
 from fluent.runtime.types import FluentNone
 
@@ -14,7 +14,7 @@ class TestFunctionCalls(unittest.TestCase):
     def setUp(self):
         self.ctx = FluentBundle(['en-US'], use_isolating=False,
                                   functions={'IDENTITY': lambda x: x})
-        self.ctx.add_messages(dedent_ftl("""
+        self.ctx.add_resource(FluentResource(dedent_ftl("""
             foo = Foo
                 .attr = Attribute
             pass-nothing       = { IDENTITY() }
@@ -24,7 +24,7 @@ class TestFunctionCalls(unittest.TestCase):
             pass-attr          = { IDENTITY(foo.attr) }
             pass-external      = { IDENTITY($ext) }
             pass-function-call = { IDENTITY(IDENTITY(1)) }
-        """))
+        """)))
 
     def test_accepts_strings(self):
         val, errs = self.ctx.format('pass-string', {})
@@ -67,9 +67,9 @@ class TestMissing(unittest.TestCase):
 
     def setUp(self):
         self.ctx = FluentBundle(['en-US'], use_isolating=False)
-        self.ctx.add_messages(dedent_ftl("""
+        self.ctx.add_resource(FluentResource(dedent_ftl("""
             missing = { MISSING(1) }
-        """))
+        """)))
 
     def test_falls_back_to_name_of_function(self):
         val, errs = self.ctx.format("missing", {})
@@ -91,10 +91,10 @@ class TestResolving(unittest.TestCase):
                                   functions={'NUMBER_PROCESSOR':
                                              number_processor})
 
-        self.ctx.add_messages(dedent_ftl("""
+        self.ctx.add_resource(FluentResource(dedent_ftl("""
             pass-number = { NUMBER_PROCESSOR(1) }
             pass-arg = { NUMBER_PROCESSOR($arg) }
-        """))
+        """)))
 
     def test_args_passed_as_numbers(self):
         val, errs = self.ctx.format('pass-arg', {'arg': 1})
@@ -120,13 +120,13 @@ class TestKeywordArgs(unittest.TestCase):
 
         self.ctx = FluentBundle(['en-US'], use_isolating=False,
                                   functions={'MYFUNC': my_function})
-        self.ctx.add_messages(dedent_ftl("""
+        self.ctx.add_resource(FluentResource(dedent_ftl("""
             pass-arg        = { MYFUNC("a") }
             pass-kwarg1     = { MYFUNC("a", kwarg1: 1) }
             pass-kwarg2     = { MYFUNC("a", kwarg2: "other") }
             pass-kwargs     = { MYFUNC("a", kwarg1: 1, kwarg2: "other") }
             pass-user-arg   = { MYFUNC($arg) }
-        """))
+        """)))
 
     def test_defaults(self):
         val, errs = self.ctx.format('pass-arg', {})

--- a/fluent.runtime/tests/format/test_functions.py
+++ b/fluent.runtime/tests/format/test_functions.py
@@ -12,9 +12,11 @@ from ..utils import dedent_ftl
 class TestFunctionCalls(unittest.TestCase):
 
     def setUp(self):
-        self.ctx = FluentBundle(['en-US'], use_isolating=False,
-                                  functions={'IDENTITY': lambda x: x})
-        self.ctx.add_resource(FluentResource(dedent_ftl("""
+        self.bundle = FluentBundle(
+            ['en-US'],
+            use_isolating=False, functions={'IDENTITY': lambda x: x}
+        )
+        self.bundle.add_resource(FluentResource(dedent_ftl("""
             foo = Foo
                 .attr = Attribute
             pass-nothing       = { IDENTITY() }
@@ -27,37 +29,37 @@ class TestFunctionCalls(unittest.TestCase):
         """)))
 
     def test_accepts_strings(self):
-        val, errs = self.ctx.format('pass-string', {})
+        val, errs = self.bundle.format_pattern(self.bundle.get_message('pass-string').value, {})
         self.assertEqual(val, "a")
         self.assertEqual(len(errs), 0)
 
     def test_accepts_numbers(self):
-        val, errs = self.ctx.format('pass-number', {})
+        val, errs = self.bundle.format_pattern(self.bundle.get_message('pass-number').value, {})
         self.assertEqual(val, "1")
         self.assertEqual(len(errs), 0)
 
     def test_accepts_entities(self):
-        val, errs = self.ctx.format('pass-message', {})
+        val, errs = self.bundle.format_pattern(self.bundle.get_message('pass-message').value, {})
         self.assertEqual(val, "Foo")
         self.assertEqual(len(errs), 0)
 
     def test_accepts_attributes(self):
-        val, errs = self.ctx.format('pass-attr', {})
+        val, errs = self.bundle.format_pattern(self.bundle.get_message('pass-attr').value, {})
         self.assertEqual(val, "Attribute")
         self.assertEqual(len(errs), 0)
 
     def test_accepts_externals(self):
-        val, errs = self.ctx.format('pass-external', {'ext': 'Ext'})
+        val, errs = self.bundle.format_pattern(self.bundle.get_message('pass-external').value, {'ext': 'Ext'})
         self.assertEqual(val, "Ext")
         self.assertEqual(len(errs), 0)
 
     def test_accepts_function_calls(self):
-        val, errs = self.ctx.format('pass-function-call', {})
+        val, errs = self.bundle.format_pattern(self.bundle.get_message('pass-function-call').value, {})
         self.assertEqual(val, "1")
         self.assertEqual(len(errs), 0)
 
     def test_wrong_arity(self):
-        val, errs = self.ctx.format('pass-nothing', {})
+        val, errs = self.bundle.format_pattern(self.bundle.get_message('pass-nothing').value, {})
         self.assertEqual(val, "IDENTITY()")
         self.assertEqual(len(errs), 1)
         self.assertEqual(type(errs[0]), TypeError)
@@ -66,13 +68,13 @@ class TestFunctionCalls(unittest.TestCase):
 class TestMissing(unittest.TestCase):
 
     def setUp(self):
-        self.ctx = FluentBundle(['en-US'], use_isolating=False)
-        self.ctx.add_resource(FluentResource(dedent_ftl("""
+        self.bundle = FluentBundle(['en-US'], use_isolating=False)
+        self.bundle.add_resource(FluentResource(dedent_ftl("""
             missing = { MISSING(1) }
         """)))
 
     def test_falls_back_to_name_of_function(self):
-        val, errs = self.ctx.format("missing", {})
+        val, errs = self.bundle.format_pattern(self.bundle.get_message('missing').value, {})
         self.assertEqual(val, "MISSING()")
         self.assertEqual(errs,
                          [FluentReferenceError("Unknown function: MISSING")])
@@ -87,23 +89,24 @@ class TestResolving(unittest.TestCase):
             self.args_passed.append(number)
             return number
 
-        self.ctx = FluentBundle(['en-US'], use_isolating=False,
-                                  functions={'NUMBER_PROCESSOR':
-                                             number_processor})
+        self.bundle = FluentBundle(
+            ['en-US'],
+            use_isolating=False, functions={'NUMBER_PROCESSOR': number_processor}
+        )
 
-        self.ctx.add_resource(FluentResource(dedent_ftl("""
+        self.bundle.add_resource(FluentResource(dedent_ftl("""
             pass-number = { NUMBER_PROCESSOR(1) }
             pass-arg = { NUMBER_PROCESSOR($arg) }
         """)))
 
     def test_args_passed_as_numbers(self):
-        val, errs = self.ctx.format('pass-arg', {'arg': 1})
+        val, errs = self.bundle.format_pattern(self.bundle.get_message('pass-arg').value, {'arg': 1})
         self.assertEqual(val, "1")
         self.assertEqual(len(errs), 0)
         self.assertEqual(self.args_passed, [1])
 
     def test_literals_passed_as_numbers(self):
-        val, errs = self.ctx.format('pass-number', {})
+        val, errs = self.bundle.format_pattern(self.bundle.get_message('pass-number').value, {})
         self.assertEqual(val, "1")
         self.assertEqual(len(errs), 0)
         self.assertEqual(self.args_passed, [1])
@@ -118,9 +121,10 @@ class TestKeywordArgs(unittest.TestCase):
             self.args_passed.append((arg, kwarg1, kwarg2))
             return arg
 
-        self.ctx = FluentBundle(['en-US'], use_isolating=False,
-                                  functions={'MYFUNC': my_function})
-        self.ctx.add_resource(FluentResource(dedent_ftl("""
+        self.bundle = FluentBundle(
+            ['en-US'], use_isolating=False, functions={'MYFUNC': my_function}
+        )
+        self.bundle.add_resource(FluentResource(dedent_ftl("""
             pass-arg        = { MYFUNC("a") }
             pass-kwarg1     = { MYFUNC("a", kwarg1: 1) }
             pass-kwarg2     = { MYFUNC("a", kwarg2: "other") }
@@ -129,31 +133,31 @@ class TestKeywordArgs(unittest.TestCase):
         """)))
 
     def test_defaults(self):
-        val, errs = self.ctx.format('pass-arg', {})
+        val, errs = self.bundle.format_pattern(self.bundle.get_message('pass-arg').value, {})
         self.assertEqual(self.args_passed,
                          [("a", None, "default")])
         self.assertEqual(len(errs), 0)
 
     def test_pass_kwarg1(self):
-        val, errs = self.ctx.format('pass-kwarg1', {})
+        val, errs = self.bundle.format_pattern(self.bundle.get_message('pass-kwarg1').value, {})
         self.assertEqual(self.args_passed,
                          [("a", 1, "default")])
         self.assertEqual(len(errs), 0)
 
     def test_pass_kwarg2(self):
-        val, errs = self.ctx.format('pass-kwarg2', {})
+        val, errs = self.bundle.format_pattern(self.bundle.get_message('pass-kwarg2').value, {})
         self.assertEqual(self.args_passed,
                          [("a", None, "other")])
         self.assertEqual(len(errs), 0)
 
     def test_pass_kwargs(self):
-        val, errs = self.ctx.format('pass-kwargs', {})
+        val, errs = self.bundle.format_pattern(self.bundle.get_message('pass-kwargs').value, {})
         self.assertEqual(self.args_passed,
                          [("a", 1, "other")])
         self.assertEqual(len(errs), 0)
 
     def test_missing_arg(self):
-        val, errs = self.ctx.format('pass-user-arg', {})
+        val, errs = self.bundle.format_pattern(self.bundle.get_message('pass-user-arg').value, {})
         self.assertEqual(self.args_passed,
                          [(FluentNone('arg'), None, "default")])
         self.assertEqual(len(errs), 1)

--- a/fluent.runtime/tests/format/test_isolating.py
+++ b/fluent.runtime/tests/format/test_isolating.py
@@ -14,8 +14,8 @@ PDI = '\u2069'
 class TestUseIsolating(unittest.TestCase):
 
     def setUp(self):
-        self.ctx = FluentBundle(['en-US'])
-        self.ctx.add_resource(FluentResource(dedent_ftl("""
+        self.bundle = FluentBundle(['en-US'])
+        self.bundle.add_resource(FluentResource(dedent_ftl("""
             foo = Foo
             bar = { foo } Bar
             baz = { $arg } Baz
@@ -23,22 +23,22 @@ class TestUseIsolating(unittest.TestCase):
         """)))
 
     def test_isolates_interpolated_message_references(self):
-        val, errs = self.ctx.format('bar', {})
+        val, errs = self.bundle.format_pattern(self.bundle.get_message('bar').value, {})
         self.assertEqual(val, FSI + "Foo" + PDI + " Bar")
         self.assertEqual(len(errs), 0)
 
     def test_isolates_interpolated_string_typed_variable_references(self):
-        val, errs = self.ctx.format('baz', {'arg': 'Arg'})
+        val, errs = self.bundle.format_pattern(self.bundle.get_message('baz').value, {'arg': 'Arg'})
         self.assertEqual(val, FSI + "Arg" + PDI + " Baz")
         self.assertEqual(len(errs), 0)
 
     def test_isolates_interpolated_number_typed_variable_references(self):
-        val, errs = self.ctx.format('baz', {'arg': 1})
+        val, errs = self.bundle.format_pattern(self.bundle.get_message('baz').value, {'arg': 1})
         self.assertEqual(val, FSI + "1" + PDI + " Baz")
         self.assertEqual(len(errs), 0)
 
     def test_isolates_complex_interpolations(self):
-        val, errs = self.ctx.format('qux', {'arg': 'Arg'})
+        val, errs = self.bundle.format_pattern(self.bundle.get_message('qux').value, {'arg': 'Arg'})
         expected_bar = FSI + FSI + "Foo" + PDI + " Bar" + PDI
         expected_baz = FSI + FSI + "Arg" + PDI + " Baz" + PDI
         self.assertEqual(val, expected_bar + " " + expected_baz)
@@ -48,19 +48,19 @@ class TestUseIsolating(unittest.TestCase):
 class TestSkipIsolating(unittest.TestCase):
 
     def setUp(self):
-        self.ctx = FluentBundle(['en-US'])
-        self.ctx.add_resource(FluentResource(dedent_ftl("""
+        self.bundle = FluentBundle(['en-US'])
+        self.bundle.add_resource(FluentResource(dedent_ftl("""
             -brand-short-name = Amaya
             foo = { -brand-short-name }
             with-arg = { $arg }
         """)))
 
     def test_skip_isolating_chars_if_just_one_message_ref(self):
-        val, errs = self.ctx.format('foo', {})
+        val, errs = self.bundle.format_pattern(self.bundle.get_message('foo').value, {})
         self.assertEqual(val, 'Amaya')
         self.assertEqual(len(errs), 0)
 
     def test_skip_isolating_chars_if_just_one_placeable_arg(self):
-        val, errs = self.ctx.format('with-arg', {'arg': 'Arg'})
+        val, errs = self.bundle.format_pattern(self.bundle.get_message('with-arg').value, {'arg': 'Arg'})
         self.assertEqual(val, 'Arg')
         self.assertEqual(len(errs), 0)

--- a/fluent.runtime/tests/format/test_isolating.py
+++ b/fluent.runtime/tests/format/test_isolating.py
@@ -2,7 +2,7 @@ from __future__ import absolute_import, unicode_literals
 
 import unittest
 
-from fluent.runtime import FluentBundle
+from fluent.runtime import FluentBundle, FluentResource
 
 from ..utils import dedent_ftl
 
@@ -15,12 +15,12 @@ class TestUseIsolating(unittest.TestCase):
 
     def setUp(self):
         self.ctx = FluentBundle(['en-US'])
-        self.ctx.add_messages(dedent_ftl("""
+        self.ctx.add_resource(FluentResource(dedent_ftl("""
             foo = Foo
             bar = { foo } Bar
             baz = { $arg } Baz
             qux = { bar } { baz }
-        """))
+        """)))
 
     def test_isolates_interpolated_message_references(self):
         val, errs = self.ctx.format('bar', {})
@@ -49,11 +49,11 @@ class TestSkipIsolating(unittest.TestCase):
 
     def setUp(self):
         self.ctx = FluentBundle(['en-US'])
-        self.ctx.add_messages(dedent_ftl("""
+        self.ctx.add_resource(FluentResource(dedent_ftl("""
             -brand-short-name = Amaya
             foo = { -brand-short-name }
             with-arg = { $arg }
-        """))
+        """)))
 
     def test_skip_isolating_chars_if_just_one_message_ref(self):
         val, errs = self.ctx.format('foo', {})

--- a/fluent.runtime/tests/format/test_parameterized_terms.py
+++ b/fluent.runtime/tests/format/test_parameterized_terms.py
@@ -2,7 +2,7 @@ from __future__ import absolute_import, unicode_literals
 
 import unittest
 
-from fluent.runtime import FluentBundle
+from fluent.runtime import FluentBundle, FluentResource
 from fluent.runtime.errors import FluentFormatError, FluentReferenceError
 
 from ..utils import dedent_ftl
@@ -12,7 +12,7 @@ class TestParameterizedTerms(unittest.TestCase):
 
     def setUp(self):
         self.ctx = FluentBundle(['en-US'], use_isolating=False)
-        self.ctx.add_messages(dedent_ftl("""
+        self.ctx.add_resource(FluentResource(dedent_ftl("""
             -thing = { $article ->
                   *[definite] the thing
                    [indefinite] a thing
@@ -24,7 +24,7 @@ class TestParameterizedTerms(unittest.TestCase):
             thing-positional-arg = { -thing("foo") }
             thing-fallback = { -thing(article: "somethingelse") }
             bad-term = { -missing() }
-        """))
+        """)))
 
     def test_argument_omitted(self):
         val, errs = self.ctx.format('thing-no-arg', {})
@@ -72,7 +72,7 @@ class TestParameterizedTermAttributes(unittest.TestCase):
 
     def setUp(self):
         self.ctx = FluentBundle(['en-US'], use_isolating=False)
-        self.ctx.add_messages(dedent_ftl("""
+        self.ctx.add_resource(FluentResource(dedent_ftl("""
             -brand = Cool Thing
                 .status = { $version ->
                     [v2]     available
@@ -93,7 +93,7 @@ class TestParameterizedTermAttributes(unittest.TestCase):
                  [ABC]  ABC option
                 *[DEF]  DEF option
             }
-        """))
+        """)))
 
     def test_with_argument(self):
         val, errs = self.ctx.format('attr-with-arg', {})
@@ -111,7 +111,7 @@ class TestNestedParameterizedTerms(unittest.TestCase):
 
     def setUp(self):
         self.ctx = FluentBundle(['en-US'], use_isolating=False)
-        self.ctx.add_messages(dedent_ftl("""
+        self.ctx.add_resource(FluentResource(dedent_ftl("""
             -thing = { $article ->
                 *[definite] { $first-letter ->
                     *[lower] the thing
@@ -127,7 +127,7 @@ class TestNestedParameterizedTerms(unittest.TestCase):
             outer-arg = This is { -thing(article: "indefinite") }.
             inner-arg = { -thing(first-letter: "upper") }.
             neither-arg = { -thing() }.
-        """))
+        """)))
 
     def test_both_args(self):
         val, errs = self.ctx.format('both-args', {})
@@ -159,13 +159,13 @@ class TestTermsCalledFromTerms(unittest.TestCase):
 
     def setUp(self):
         self.ctx = FluentBundle(['en-US'], use_isolating=False)
-        self.ctx.add_messages(dedent_ftl("""
+        self.ctx.add_resource(FluentResource(dedent_ftl("""
             -foo = {$a} {$b}
             -bar = {-foo(b: 2)}
             -baz = {-foo}
             ref-bar = {-bar(a: 1)}
             ref-baz = {-baz(a: 1)}
-        """))
+        """)))
 
     def test_term_args_isolated_with_call_syntax(self):
         val, errs = self.ctx.format('ref-bar', {})
@@ -182,11 +182,11 @@ class TestMessagesCalledFromTerms(unittest.TestCase):
 
     def setUp(self):
         self.ctx = FluentBundle(['en-US'], use_isolating=False)
-        self.ctx.add_messages(dedent_ftl("""
+        self.ctx.add_resource(FluentResource(dedent_ftl("""
             msg = Msg is {$arg}
             -foo = {msg}
             ref-foo = {-foo(arg: 1)}
-        """))
+        """)))
 
     def test_messages_inherit_term_args(self):
         # This behaviour may change in future, message calls might be

--- a/fluent.runtime/tests/format/test_placeables.py
+++ b/fluent.runtime/tests/format/test_placeables.py
@@ -10,8 +10,8 @@ from ..utils import dedent_ftl
 
 class TestPlaceables(unittest.TestCase):
     def setUp(self):
-        self.ctx = FluentBundle(['en-US'], use_isolating=False)
-        self.ctx.add_resource(FluentResource(dedent_ftl("""
+        self.bundle = FluentBundle(['en-US'], use_isolating=False)
+        self.bundle.add_resource(FluentResource(dedent_ftl("""
             message = Message
                     .attr = Message Attribute
             -term = Term
@@ -42,46 +42,46 @@ class TestPlaceables(unittest.TestCase):
         """)))
 
     def test_placeable_message(self):
-        val, errs = self.ctx.format('uses-message', {})
+        val, errs = self.bundle.format_pattern(self.bundle.get_message('uses-message').value, {})
         self.assertEqual(val, 'Message')
         self.assertEqual(len(errs), 0)
 
     def test_placeable_message_attr(self):
-        val, errs = self.ctx.format('uses-message-attr', {})
+        val, errs = self.bundle.format_pattern(self.bundle.get_message('uses-message-attr').value, {})
         self.assertEqual(val, 'Message Attribute')
         self.assertEqual(len(errs), 0)
 
     def test_placeable_term(self):
-        val, errs = self.ctx.format('uses-term', {})
+        val, errs = self.bundle.format_pattern(self.bundle.get_message('uses-term').value, {})
         self.assertEqual(val, 'Term')
         self.assertEqual(len(errs), 0)
 
     def test_placeable_bad_message(self):
-        val, errs = self.ctx.format('bad-message-ref', {})
-        self.assertEqual(val, 'Text not-a-message')
+        val, errs = self.bundle.format_pattern(self.bundle.get_message('bad-message-ref').value, {})
+        self.assertEqual(val, 'Text {not-a-message}')
         self.assertEqual(len(errs), 1)
         self.assertEqual(
             errs,
             [FluentReferenceError("Unknown message: not-a-message")])
 
     def test_placeable_bad_message_attr(self):
-        val, errs = self.ctx.format('bad-message-attr-ref', {})
-        self.assertEqual(val, 'Text Message')
+        val, errs = self.bundle.format_pattern(self.bundle.get_message('bad-message-attr-ref').value, {})
+        self.assertEqual(val, 'Text {message.not-an-attr}')
         self.assertEqual(len(errs), 1)
         self.assertEqual(
             errs,
             [FluentReferenceError("Unknown attribute: message.not-an-attr")])
 
     def test_placeable_bad_term(self):
-        val, errs = self.ctx.format('bad-term-ref', {})
-        self.assertEqual(val, 'Text -not-a-term')
+        val, errs = self.bundle.format_pattern(self.bundle.get_message('bad-term-ref').value, {})
+        self.assertEqual(val, 'Text {-not-a-term}')
         self.assertEqual(len(errs), 1)
         self.assertEqual(
             errs,
             [FluentReferenceError("Unknown term: -not-a-term")])
 
     def test_cycle_detection(self):
-        val, errs = self.ctx.format('self-referencing-message', {})
+        val, errs = self.bundle.format_pattern(self.bundle.get_message('self-referencing-message').value, {})
         self.assertEqual(val, 'Text ???')
         self.assertEqual(len(errs), 1)
         self.assertEqual(
@@ -89,7 +89,7 @@ class TestPlaceables(unittest.TestCase):
             [FluentCyclicReferenceError("Cyclic reference")])
 
     def test_mutual_cycle_detection(self):
-        val, errs = self.ctx.format('cyclic-msg1', {})
+        val, errs = self.bundle.format_pattern(self.bundle.get_message('cyclic-msg1').value, {})
         self.assertEqual(val, 'Text1 Text2 ???')
         self.assertEqual(len(errs), 1)
         self.assertEqual(
@@ -97,53 +97,53 @@ class TestPlaceables(unittest.TestCase):
             [FluentCyclicReferenceError("Cyclic reference")])
 
     def test_allowed_self_reference(self):
-        val, errs = self.ctx.format('self-attribute-ref-ok', {})
+        val, errs = self.bundle.format_pattern(self.bundle.get_message('self-attribute-ref-ok').value, {})
         self.assertEqual(val, 'Parent Attribute')
         self.assertEqual(len(errs), 0)
-        val, errs = self.ctx.format('self-parent-ref-ok.attr', {})
+        val, errs = self.bundle.format_pattern(self.bundle.get_message('self-parent-ref-ok').attributes['attr'], {})
         self.assertEqual(val, 'Attribute Parent')
         self.assertEqual(len(errs), 0)
 
 
 class TestSingleElementPattern(unittest.TestCase):
     def test_single_literal_number_isolating(self):
-        self.ctx = FluentBundle(['en-US'], use_isolating=True)
-        self.ctx.add_resource(FluentResource('foo = { 1 }'))
-        val, errs = self.ctx.format('foo')
+        self.bundle = FluentBundle(['en-US'], use_isolating=True)
+        self.bundle.add_resource(FluentResource('foo = { 1 }'))
+        val, errs = self.bundle.format_pattern(self.bundle.get_message('foo').value)
         self.assertEqual(val, '1')
         self.assertEqual(errs, [])
 
     def test_single_literal_number_non_isolating(self):
-        self.ctx = FluentBundle(['en-US'], use_isolating=False)
-        self.ctx.add_resource(FluentResource('foo = { 1 }'))
-        val, errs = self.ctx.format('foo')
+        self.bundle = FluentBundle(['en-US'], use_isolating=False)
+        self.bundle.add_resource(FluentResource('foo = { 1 }'))
+        val, errs = self.bundle.format_pattern(self.bundle.get_message('foo').value)
         self.assertEqual(val, '1')
         self.assertEqual(errs, [])
 
     def test_single_arg_number_isolating(self):
-        self.ctx = FluentBundle(['en-US'], use_isolating=True)
-        self.ctx.add_resource(FluentResource('foo = { $arg }'))
-        val, errs = self.ctx.format('foo', {'arg': 1})
+        self.bundle = FluentBundle(['en-US'], use_isolating=True)
+        self.bundle.add_resource(FluentResource('foo = { $arg }'))
+        val, errs = self.bundle.format_pattern(self.bundle.get_message('foo').value, {'arg': 1})
         self.assertEqual(val, '1')
         self.assertEqual(errs, [])
 
     def test_single_arg_number_non_isolating(self):
-        self.ctx = FluentBundle(['en-US'], use_isolating=False)
-        self.ctx.add_resource(FluentResource('foo = { $arg }'))
-        val, errs = self.ctx.format('foo', {'arg': 1})
+        self.bundle = FluentBundle(['en-US'], use_isolating=False)
+        self.bundle.add_resource(FluentResource('foo = { $arg }'))
+        val, errs = self.bundle.format_pattern(self.bundle.get_message('foo').value, {'arg': 1})
         self.assertEqual(val, '1')
         self.assertEqual(errs, [])
 
     def test_single_arg_missing_isolating(self):
-        self.ctx = FluentBundle(['en-US'], use_isolating=True)
-        self.ctx.add_resource(FluentResource('foo = { $arg }'))
-        val, errs = self.ctx.format('foo')
+        self.bundle = FluentBundle(['en-US'], use_isolating=True)
+        self.bundle.add_resource(FluentResource('foo = { $arg }'))
+        val, errs = self.bundle.format_pattern(self.bundle.get_message('foo').value)
         self.assertEqual(val, 'arg')
         self.assertEqual(len(errs), 1)
 
     def test_single_arg_missing_non_isolating(self):
-        self.ctx = FluentBundle(['en-US'], use_isolating=False)
-        self.ctx.add_resource(FluentResource('foo = { $arg }'))
-        val, errs = self.ctx.format('foo')
+        self.bundle = FluentBundle(['en-US'], use_isolating=False)
+        self.bundle.add_resource(FluentResource('foo = { $arg }'))
+        val, errs = self.bundle.format_pattern(self.bundle.get_message('foo').value)
         self.assertEqual(val, 'arg')
         self.assertEqual(len(errs), 1)

--- a/fluent.runtime/tests/format/test_placeables.py
+++ b/fluent.runtime/tests/format/test_placeables.py
@@ -2,7 +2,7 @@ from __future__ import absolute_import, unicode_literals
 
 import unittest
 
-from fluent.runtime import FluentBundle
+from fluent.runtime import FluentBundle, FluentResource
 from fluent.runtime.errors import FluentCyclicReferenceError, FluentReferenceError
 
 from ..utils import dedent_ftl
@@ -11,7 +11,7 @@ from ..utils import dedent_ftl
 class TestPlaceables(unittest.TestCase):
     def setUp(self):
         self.ctx = FluentBundle(['en-US'], use_isolating=False)
-        self.ctx.add_messages(dedent_ftl("""
+        self.ctx.add_resource(FluentResource(dedent_ftl("""
             message = Message
                     .attr = Message Attribute
             -term = Term
@@ -39,7 +39,7 @@ class TestPlaceables(unittest.TestCase):
                                   .attr = Attribute
             self-parent-ref-ok = Parent
                                .attr =  Attribute { self-parent-ref-ok }
-        """))
+        """)))
 
     def test_placeable_message(self):
         val, errs = self.ctx.format('uses-message', {})
@@ -108,42 +108,42 @@ class TestPlaceables(unittest.TestCase):
 class TestSingleElementPattern(unittest.TestCase):
     def test_single_literal_number_isolating(self):
         self.ctx = FluentBundle(['en-US'], use_isolating=True)
-        self.ctx.add_messages('foo = { 1 }')
+        self.ctx.add_resource(FluentResource('foo = { 1 }'))
         val, errs = self.ctx.format('foo')
         self.assertEqual(val, '1')
         self.assertEqual(errs, [])
 
     def test_single_literal_number_non_isolating(self):
         self.ctx = FluentBundle(['en-US'], use_isolating=False)
-        self.ctx.add_messages('foo = { 1 }')
+        self.ctx.add_resource(FluentResource('foo = { 1 }'))
         val, errs = self.ctx.format('foo')
         self.assertEqual(val, '1')
         self.assertEqual(errs, [])
 
     def test_single_arg_number_isolating(self):
         self.ctx = FluentBundle(['en-US'], use_isolating=True)
-        self.ctx.add_messages('foo = { $arg }')
+        self.ctx.add_resource(FluentResource('foo = { $arg }'))
         val, errs = self.ctx.format('foo', {'arg': 1})
         self.assertEqual(val, '1')
         self.assertEqual(errs, [])
 
     def test_single_arg_number_non_isolating(self):
         self.ctx = FluentBundle(['en-US'], use_isolating=False)
-        self.ctx.add_messages('foo = { $arg }')
+        self.ctx.add_resource(FluentResource('foo = { $arg }'))
         val, errs = self.ctx.format('foo', {'arg': 1})
         self.assertEqual(val, '1')
         self.assertEqual(errs, [])
 
     def test_single_arg_missing_isolating(self):
         self.ctx = FluentBundle(['en-US'], use_isolating=True)
-        self.ctx.add_messages('foo = { $arg }')
+        self.ctx.add_resource(FluentResource('foo = { $arg }'))
         val, errs = self.ctx.format('foo')
         self.assertEqual(val, 'arg')
         self.assertEqual(len(errs), 1)
 
     def test_single_arg_missing_non_isolating(self):
         self.ctx = FluentBundle(['en-US'], use_isolating=False)
-        self.ctx.add_messages('foo = { $arg }')
+        self.ctx.add_resource(FluentResource('foo = { $arg }'))
         val, errs = self.ctx.format('foo')
         self.assertEqual(val, 'arg')
         self.assertEqual(len(errs), 1)

--- a/fluent.runtime/tests/format/test_primitives.py
+++ b/fluent.runtime/tests/format/test_primitives.py
@@ -10,8 +10,8 @@ from ..utils import dedent_ftl
 
 class TestSimpleStringValue(unittest.TestCase):
     def setUp(self):
-        self.ctx = FluentBundle(['en-US'], use_isolating=False)
-        self.ctx.add_resource(FluentResource(dedent_ftl(r"""
+        self.bundle = FluentBundle(['en-US'], use_isolating=False)
+        self.bundle.add_resource(FluentResource(dedent_ftl(r"""
             foo               = Foo
             placeable-literal = { "Foo" } Bar
             placeable-message = { foo } Bar
@@ -32,50 +32,50 @@ class TestSimpleStringValue(unittest.TestCase):
         """)))
 
     def test_can_be_used_as_a_value(self):
-        val, errs = self.ctx.format('foo', {})
+        val, errs = self.bundle.format_pattern(self.bundle.get_message('foo').value, {})
         self.assertEqual(val, 'Foo')
         self.assertEqual(len(errs), 0)
 
     def test_can_be_used_in_a_placeable(self):
-        val, errs = self.ctx.format('placeable-literal', {})
+        val, errs = self.bundle.format_pattern(self.bundle.get_message('placeable-literal').value, {})
         self.assertEqual(val, 'Foo Bar')
         self.assertEqual(len(errs), 0)
 
     def test_can_be_a_value_of_a_message_referenced_in_a_placeable(self):
-        val, errs = self.ctx.format('placeable-message', {})
+        val, errs = self.bundle.format_pattern(self.bundle.get_message('placeable-message').value, {})
         self.assertEqual(val, 'Foo Bar')
         self.assertEqual(len(errs), 0)
 
     def test_can_be_a_selector(self):
-        val, errs = self.ctx.format('selector-literal', {})
+        val, errs = self.bundle.format_pattern(self.bundle.get_message('selector-literal').value, {})
         self.assertEqual(val, 'Member 1')
         self.assertEqual(len(errs), 0)
 
     def test_can_be_used_as_an_attribute_value(self):
-        val, errs = self.ctx.format('bar.attr', {})
+        val, errs = self.bundle.format_pattern(self.bundle.get_message('bar').attributes['attr'], {})
         self.assertEqual(val, 'Bar Attribute')
         self.assertEqual(len(errs), 0)
 
     def test_can_be_a_value_of_an_attribute_used_in_a_placeable(self):
-        val, errs = self.ctx.format('placeable-attr', {})
+        val, errs = self.bundle.format_pattern(self.bundle.get_message('placeable-attr').value, {})
         self.assertEqual(val, 'Bar Attribute')
         self.assertEqual(len(errs), 0)
 
     def test_can_be_a_value_of_an_attribute_used_as_a_selector(self):
-        val, errs = self.ctx.format('selector-attr', {})
+        val, errs = self.bundle.format_pattern(self.bundle.get_message('selector-attr').value, {})
         self.assertEqual(val, 'Member 3')
         self.assertEqual(len(errs), 0)
 
     def test_escapes(self):
-        val, errs = self.ctx.format('escapes', {})
+        val, errs = self.bundle.format_pattern(self.bundle.get_message('escapes').value, {})
         self.assertEqual(val, r'    stuffɘ}"\end')
         self.assertEqual(len(errs), 0)
 
 
 class TestComplexStringValue(unittest.TestCase):
     def setUp(self):
-        self.ctx = FluentBundle(['en-US'], use_isolating=False)
-        self.ctx.add_resource(FluentResource(dedent_ftl("""
+        self.bundle = FluentBundle(['en-US'], use_isolating=False)
+        self.bundle.add_resource(FluentResource(dedent_ftl("""
             foo               = Foo
             bar               = { foo }Bar
 
@@ -96,35 +96,35 @@ class TestComplexStringValue(unittest.TestCase):
         """)))
 
     def test_can_be_used_as_a_value(self):
-        val, errs = self.ctx.format('bar', {})
+        val, errs = self.bundle.format_pattern(self.bundle.get_message('bar').value, {})
         self.assertEqual(val, 'FooBar')
         self.assertEqual(len(errs), 0)
 
     def test_can_be_value_of_a_message_referenced_in_a_placeable(self):
-        val, errs = self.ctx.format('placeable-message', {})
+        val, errs = self.bundle.format_pattern(self.bundle.get_message('placeable-message').value, {})
         self.assertEqual(val, 'FooBarBaz')
         self.assertEqual(len(errs), 0)
 
     def test_can_be_used_as_an_attribute_value(self):
-        val, errs = self.ctx.format('baz.attr', {})
+        val, errs = self.bundle.format_pattern(self.bundle.get_message('baz').attributes['attr'], {})
         self.assertEqual(val, 'FooBarBazAttribute')
         self.assertEqual(len(errs), 0)
 
     def test_can_be_a_value_of_an_attribute_used_in_a_placeable(self):
-        val, errs = self.ctx.format('placeable-attr', {})
+        val, errs = self.bundle.format_pattern(self.bundle.get_message('placeable-attr').value, {})
         self.assertEqual(val, 'FooBarBazAttribute')
         self.assertEqual(len(errs), 0)
 
     def test_can_be_a_value_of_an_attribute_used_as_a_selector(self):
-        val, errs = self.ctx.format('selector-attr', {})
+        val, errs = self.bundle.format_pattern(self.bundle.get_message('selector-attr').value, {})
         self.assertEqual(val, 'FooBarQux')
         self.assertEqual(len(errs), 0)
 
 
 class TestNumbers(unittest.TestCase):
     def setUp(self):
-        self.ctx = FluentBundle(['en-US'], use_isolating=False)
-        self.ctx.add_resource(FluentResource(dedent_ftl("""
+        self.bundle = FluentBundle(['en-US'], use_isolating=False)
+        self.bundle.add_resource(FluentResource(dedent_ftl("""
             one           =  { 1 }
             one_point_two =  { 1.2 }
             select        =  { 1 ->
@@ -134,16 +134,16 @@ class TestNumbers(unittest.TestCase):
         """)))
 
     def test_int_number_used_in_placeable(self):
-        val, errs = self.ctx.format('one', {})
+        val, errs = self.bundle.format_pattern(self.bundle.get_message('one').value, {})
         self.assertEqual(val, '1')
         self.assertEqual(len(errs), 0)
 
     def test_float_number_used_in_placeable(self):
-        val, errs = self.ctx.format('one_point_two', {})
+        val, errs = self.bundle.format_pattern(self.bundle.get_message('one_point_two').value, {})
         self.assertEqual(val, '1.2')
         self.assertEqual(len(errs), 0)
 
     def test_can_be_used_as_a_selector(self):
-        val, errs = self.ctx.format('select', {})
+        val, errs = self.bundle.format_pattern(self.bundle.get_message('select').value, {})
         self.assertEqual(val, 'One')
         self.assertEqual(len(errs), 0)

--- a/fluent.runtime/tests/format/test_primitives.py
+++ b/fluent.runtime/tests/format/test_primitives.py
@@ -3,7 +3,7 @@ from __future__ import absolute_import, unicode_literals
 
 import unittest
 
-from fluent.runtime import FluentBundle
+from fluent.runtime import FluentBundle, FluentResource
 
 from ..utils import dedent_ftl
 
@@ -11,7 +11,7 @@ from ..utils import dedent_ftl
 class TestSimpleStringValue(unittest.TestCase):
     def setUp(self):
         self.ctx = FluentBundle(['en-US'], use_isolating=False)
-        self.ctx.add_messages(dedent_ftl(r"""
+        self.ctx.add_resource(FluentResource(dedent_ftl(r"""
             foo               = Foo
             placeable-literal = { "Foo" } Bar
             placeable-message = { foo } Bar
@@ -29,7 +29,7 @@ class TestSimpleStringValue(unittest.TestCase):
                *[other]        Member 4
              }
             escapes = {"    "}stuff{"\u0258}\"\\end"}
-        """))
+        """)))
 
     def test_can_be_used_as_a_value(self):
         val, errs = self.ctx.format('foo', {})
@@ -75,7 +75,7 @@ class TestSimpleStringValue(unittest.TestCase):
 class TestComplexStringValue(unittest.TestCase):
     def setUp(self):
         self.ctx = FluentBundle(['en-US'], use_isolating=False)
-        self.ctx.add_messages(dedent_ftl("""
+        self.ctx.add_resource(FluentResource(dedent_ftl("""
             foo               = Foo
             bar               = { foo }Bar
 
@@ -93,7 +93,7 @@ class TestComplexStringValue(unittest.TestCase):
                 [FooBarQuxAttribute] FooBarQux
                *[other] Other
              }
-        """))
+        """)))
 
     def test_can_be_used_as_a_value(self):
         val, errs = self.ctx.format('bar', {})
@@ -124,14 +124,14 @@ class TestComplexStringValue(unittest.TestCase):
 class TestNumbers(unittest.TestCase):
     def setUp(self):
         self.ctx = FluentBundle(['en-US'], use_isolating=False)
-        self.ctx.add_messages(dedent_ftl("""
+        self.ctx.add_resource(FluentResource(dedent_ftl("""
             one           =  { 1 }
             one_point_two =  { 1.2 }
             select        =  { 1 ->
                *[0] Zero
                 [1] One
              }
-        """))
+        """)))
 
     def test_int_number_used_in_placeable(self):
         val, errs = self.ctx.format('one', {})

--- a/fluent.runtime/tests/format/test_select_expression.py
+++ b/fluent.runtime/tests/format/test_select_expression.py
@@ -11,58 +11,58 @@ from ..utils import dedent_ftl
 class TestSelectExpressionWithStrings(unittest.TestCase):
 
     def setUp(self):
-        self.ctx = FluentBundle(['en-US'], use_isolating=False)
+        self.bundle = FluentBundle(['en-US'], use_isolating=False)
 
     def test_with_a_matching_selector(self):
-        self.ctx.add_resource(FluentResource(dedent_ftl("""
+        self.bundle.add_resource(FluentResource(dedent_ftl("""
             foo = { "a" ->
                 [a] A
                *[b] B
              }
         """)))
-        val, errs = self.ctx.format('foo', {})
+        val, errs = self.bundle.format_pattern(self.bundle.get_message('foo').value, {})
         self.assertEqual(val, "A")
         self.assertEqual(len(errs), 0)
 
     def test_with_a_non_matching_selector(self):
-        self.ctx.add_resource(FluentResource(dedent_ftl("""
+        self.bundle.add_resource(FluentResource(dedent_ftl("""
             foo = { "c" ->
                 [a] A
                *[b] B
              }
         """)))
-        val, errs = self.ctx.format('foo', {})
+        val, errs = self.bundle.format_pattern(self.bundle.get_message('foo').value, {})
         self.assertEqual(val, "B")
         self.assertEqual(len(errs), 0)
 
     def test_with_a_missing_selector(self):
-        self.ctx.add_resource(FluentResource(dedent_ftl("""
+        self.bundle.add_resource(FluentResource(dedent_ftl("""
             foo = { $none ->
                 [a] A
                *[b] B
              }
         """)))
-        val, errs = self.ctx.format('foo', {})
+        val, errs = self.bundle.format_pattern(self.bundle.get_message('foo').value, {})
         self.assertEqual(val, "B")
         self.assertEqual(errs,
                          [FluentReferenceError("Unknown external: none")])
 
     def test_with_argument_expression(self):
-        self.ctx.add_resource(FluentResource(dedent_ftl("""
+        self.bundle.add_resource(FluentResource(dedent_ftl("""
             foo = { $arg ->
                 [a] A
                *[b] B
              }
         """)))
-        val, errs = self.ctx.format('foo', {'arg': 'a'})
+        val, errs = self.bundle.format_pattern(self.bundle.get_message('foo').value, {'arg': 'a'})
         self.assertEqual(val, "A")
 
 
 class TestSelectExpressionWithNumbers(unittest.TestCase):
 
     def setUp(self):
-        self.ctx = FluentBundle(['en-US'], use_isolating=False)
-        self.ctx.add_resource(FluentResource(dedent_ftl("""
+        self.bundle = FluentBundle(['en-US'], use_isolating=False)
+        self.bundle.add_resource(FluentResource(dedent_ftl("""
             foo = { 1 ->
                *[0] A
                 [1] B
@@ -85,39 +85,39 @@ class TestSelectExpressionWithNumbers(unittest.TestCase):
         """)))
 
     def test_selects_the_right_variant(self):
-        val, errs = self.ctx.format('foo', {})
+        val, errs = self.bundle.format_pattern(self.bundle.get_message('foo').value, {})
         self.assertEqual(val, "B")
         self.assertEqual(len(errs), 0)
 
     def test_with_a_non_matching_selector(self):
-        val, errs = self.ctx.format('bar', {})
+        val, errs = self.bundle.format_pattern(self.bundle.get_message('bar').value, {})
         self.assertEqual(val, "A")
         self.assertEqual(len(errs), 0)
 
     def test_with_a_missing_selector(self):
-        val, errs = self.ctx.format('baz', {})
+        val, errs = self.bundle.format_pattern(self.bundle.get_message('baz').value, {})
         self.assertEqual(val, "A")
         self.assertEqual(errs,
                          [FluentReferenceError("Unknown external: num")])
 
     def test_with_argument_int(self):
-        val, errs = self.ctx.format('baz', {'num': 1})
+        val, errs = self.bundle.format_pattern(self.bundle.get_message('baz').value, {'num': 1})
         self.assertEqual(val, "B")
 
     def test_with_argument_float(self):
-        val, errs = self.ctx.format('baz', {'num': 1.0})
+        val, errs = self.bundle.format_pattern(self.bundle.get_message('baz').value, {'num': 1.0})
         self.assertEqual(val, "B")
 
     def test_with_float(self):
-        val, errs = self.ctx.format('qux', {})
+        val, errs = self.bundle.format_pattern(self.bundle.get_message('qux').value, {})
         self.assertEqual(val, "B")
 
 
 class TestSelectExpressionWithPluralCategories(unittest.TestCase):
 
     def setUp(self):
-        self.ctx = FluentBundle(['en-US'], use_isolating=False)
-        self.ctx.add_resource(FluentResource(dedent_ftl("""
+        self.bundle = FluentBundle(['en-US'], use_isolating=False)
+        self.bundle.add_resource(FluentResource(dedent_ftl("""
             foo = { 1 ->
                 [one] A
                *[other] B
@@ -140,37 +140,37 @@ class TestSelectExpressionWithPluralCategories(unittest.TestCase):
         """)))
 
     def test_selects_the_right_category(self):
-        val, errs = self.ctx.format('foo', {})
+        val, errs = self.bundle.format_pattern(self.bundle.get_message('foo').value, {})
         self.assertEqual(val, "A")
         self.assertEqual(len(errs), 0)
 
     def test_selects_exact_match(self):
-        val, errs = self.ctx.format('bar', {})
+        val, errs = self.bundle.format_pattern(self.bundle.get_message('bar').value, {})
         self.assertEqual(val, "A")
         self.assertEqual(len(errs), 0)
 
     def test_selects_default_with_invalid_selector(self):
-        val, errs = self.ctx.format('baz', {})
+        val, errs = self.bundle.format_pattern(self.bundle.get_message('baz').value, {})
         self.assertEqual(val, "B")
         self.assertEqual(len(errs), 0)
 
     def test_with_a_missing_selector(self):
-        val, errs = self.ctx.format('qux', {})
+        val, errs = self.bundle.format_pattern(self.bundle.get_message('qux').value, {})
         self.assertEqual(val, "B")
         self.assertEqual(errs,
                          [FluentReferenceError("Unknown external: num")])
 
     def test_with_argument_integer(self):
-        val, errs = self.ctx.format('qux', {'num': 1})
+        val, errs = self.bundle.format_pattern(self.bundle.get_message('qux').value, {'num': 1})
         self.assertEqual(val, "A")
         self.assertEqual(len(errs), 0)
 
-        val, errs = self.ctx.format('qux', {'num': 2})
+        val, errs = self.bundle.format_pattern(self.bundle.get_message('qux').value, {'num': 2})
         self.assertEqual(val, "B")
         self.assertEqual(len(errs), 0)
 
     def test_with_argument_float(self):
-        val, errs = self.ctx.format('qux', {'num': 1.0})
+        val, errs = self.bundle.format_pattern(self.bundle.get_message('qux').value, {'num': 1.0})
         self.assertEqual(val, "A")
         self.assertEqual(len(errs), 0)
 
@@ -178,8 +178,8 @@ class TestSelectExpressionWithPluralCategories(unittest.TestCase):
 class TestSelectExpressionWithTerms(unittest.TestCase):
 
     def setUp(self):
-        self.ctx = FluentBundle(['en-US'], use_isolating=False)
-        self.ctx.add_resource(FluentResource(dedent_ftl("""
+        self.bundle = FluentBundle(['en-US'], use_isolating=False)
+        self.bundle.add_resource(FluentResource(dedent_ftl("""
             -my-term = term
                  .attr = termattribute
 
@@ -200,17 +200,17 @@ class TestSelectExpressionWithTerms(unittest.TestCase):
         """)))
 
     def test_ref_term_attribute(self):
-        val, errs = self.ctx.format('ref-term-attr')
+        val, errs = self.bundle.format_pattern(self.bundle.get_message('ref-term-attr').value)
         self.assertEqual(val, "Term Attribute")
         self.assertEqual(len(errs), 0)
 
     def test_ref_term_attribute_fallback(self):
-        val, errs = self.ctx.format('ref-term-attr-other')
+        val, errs = self.bundle.format_pattern(self.bundle.get_message('ref-term-attr-other').value)
         self.assertEqual(val, "Other")
         self.assertEqual(len(errs), 0)
 
     def test_ref_term_attribute_missing(self):
-        val, errs = self.ctx.format('ref-term-attr-missing')
+        val, errs = self.bundle.format_pattern(self.bundle.get_message('ref-term-attr-missing').value)
         self.assertEqual(val, "Other")
         self.assertEqual(len(errs), 1)
         self.assertEqual(errs,

--- a/fluent.runtime/tests/format/test_select_expression.py
+++ b/fluent.runtime/tests/format/test_select_expression.py
@@ -2,7 +2,7 @@ from __future__ import absolute_import, unicode_literals
 
 import unittest
 
-from fluent.runtime import FluentBundle
+from fluent.runtime import FluentBundle, FluentResource
 from fluent.runtime.errors import FluentReferenceError
 
 from ..utils import dedent_ftl
@@ -14,46 +14,46 @@ class TestSelectExpressionWithStrings(unittest.TestCase):
         self.ctx = FluentBundle(['en-US'], use_isolating=False)
 
     def test_with_a_matching_selector(self):
-        self.ctx.add_messages(dedent_ftl("""
+        self.ctx.add_resource(FluentResource(dedent_ftl("""
             foo = { "a" ->
                 [a] A
                *[b] B
              }
-        """))
+        """)))
         val, errs = self.ctx.format('foo', {})
         self.assertEqual(val, "A")
         self.assertEqual(len(errs), 0)
 
     def test_with_a_non_matching_selector(self):
-        self.ctx.add_messages(dedent_ftl("""
+        self.ctx.add_resource(FluentResource(dedent_ftl("""
             foo = { "c" ->
                 [a] A
                *[b] B
              }
-        """))
+        """)))
         val, errs = self.ctx.format('foo', {})
         self.assertEqual(val, "B")
         self.assertEqual(len(errs), 0)
 
     def test_with_a_missing_selector(self):
-        self.ctx.add_messages(dedent_ftl("""
+        self.ctx.add_resource(FluentResource(dedent_ftl("""
             foo = { $none ->
                 [a] A
                *[b] B
              }
-        """))
+        """)))
         val, errs = self.ctx.format('foo', {})
         self.assertEqual(val, "B")
         self.assertEqual(errs,
                          [FluentReferenceError("Unknown external: none")])
 
     def test_with_argument_expression(self):
-        self.ctx.add_messages(dedent_ftl("""
+        self.ctx.add_resource(FluentResource(dedent_ftl("""
             foo = { $arg ->
                 [a] A
                *[b] B
              }
-        """))
+        """)))
         val, errs = self.ctx.format('foo', {'arg': 'a'})
         self.assertEqual(val, "A")
 
@@ -62,7 +62,7 @@ class TestSelectExpressionWithNumbers(unittest.TestCase):
 
     def setUp(self):
         self.ctx = FluentBundle(['en-US'], use_isolating=False)
-        self.ctx.add_messages(dedent_ftl("""
+        self.ctx.add_resource(FluentResource(dedent_ftl("""
             foo = { 1 ->
                *[0] A
                 [1] B
@@ -82,7 +82,7 @@ class TestSelectExpressionWithNumbers(unittest.TestCase):
                *[0] A
                 [1] B
              }
-        """))
+        """)))
 
     def test_selects_the_right_variant(self):
         val, errs = self.ctx.format('foo', {})
@@ -117,7 +117,7 @@ class TestSelectExpressionWithPluralCategories(unittest.TestCase):
 
     def setUp(self):
         self.ctx = FluentBundle(['en-US'], use_isolating=False)
-        self.ctx.add_messages(dedent_ftl("""
+        self.ctx.add_resource(FluentResource(dedent_ftl("""
             foo = { 1 ->
                 [one] A
                *[other] B
@@ -137,7 +137,7 @@ class TestSelectExpressionWithPluralCategories(unittest.TestCase):
                 [one] A
                *[other] B
              }
-        """))
+        """)))
 
     def test_selects_the_right_category(self):
         val, errs = self.ctx.format('foo', {})
@@ -179,7 +179,7 @@ class TestSelectExpressionWithTerms(unittest.TestCase):
 
     def setUp(self):
         self.ctx = FluentBundle(['en-US'], use_isolating=False)
-        self.ctx.add_messages(dedent_ftl("""
+        self.ctx.add_resource(FluentResource(dedent_ftl("""
             -my-term = term
                  .attr = termattribute
 
@@ -197,7 +197,7 @@ class TestSelectExpressionWithTerms(unittest.TestCase):
                     [x]      Term Attribute
                    *[other]  Other
             }
-        """))
+        """)))
 
     def test_ref_term_attribute(self):
         val, errs = self.ctx.format('ref-term-attr')

--- a/fluent.runtime/tests/test_bomb.py
+++ b/fluent.runtime/tests/test_bomb.py
@@ -2,7 +2,7 @@ from __future__ import absolute_import, unicode_literals
 
 import unittest
 
-from fluent.runtime import FluentBundle
+from fluent.runtime import FluentBundle, FluentResource
 
 from .utils import dedent_ftl
 
@@ -11,7 +11,7 @@ class TestBillionLaughs(unittest.TestCase):
 
     def setUp(self):
         self.ctx = FluentBundle(['en-US'], use_isolating=False)
-        self.ctx.add_messages(dedent_ftl("""
+        self.ctx.add_resource(FluentResource(dedent_ftl("""
             lol0 = 01234567890123456789012345678901234567890123456789
             lol1 = {lol0}{lol0}{lol0}{lol0}{lol0}{lol0}{lol0}{lol0}{lol0}{lol0}
             lol2 = {lol1}{lol1}{lol1}{lol1}{lol1}{lol1}{lol1}{lol1}{lol1}{lol1}
@@ -28,7 +28,7 @@ class TestBillionLaughs(unittest.TestCase):
             elol6 = {elol5}{elol5}{elol5}{elol5}{elol5}{elol5}{elol5}{elol5}{elol5}{elol5}
             emptylolz = {elol6}
 
-        """))
+        """)))
 
     def test_max_length_protection(self):
         val, errs = self.ctx.format('lolz')

--- a/fluent.runtime/tests/test_bomb.py
+++ b/fluent.runtime/tests/test_bomb.py
@@ -31,7 +31,7 @@ class TestBillionLaughs(unittest.TestCase):
         """)))
 
     def test_max_length_protection(self):
-        val, errs = self.ctx.format('lolz')
+        val, errs = self.ctx.format_pattern(self.ctx.get_message('lolz').value)
         self.assertEqual(val, '{???}')
         self.assertNotEqual(len(errs), 0)
         self.assertIn('Too many characters', str(errs[-1]))
@@ -39,7 +39,7 @@ class TestBillionLaughs(unittest.TestCase):
     def test_max_expansions_protection(self):
         # Without protection, emptylolz will take a really long time to
         # evaluate, although it generates an empty message.
-        val, errs = self.ctx.format('emptylolz')
+        val, errs = self.ctx.format_pattern(self.ctx.get_message('emptylolz').value)
         self.assertEqual(val, '{???}')
         self.assertEqual(len(errs), 1)
         self.assertIn('Too many parts', str(errs[-1]))

--- a/fluent.runtime/tests/test_bundle.py
+++ b/fluent.runtime/tests/test_bundle.py
@@ -18,9 +18,9 @@ class TestFluentBundle(unittest.TestCase):
             bar = Bar
             -baz = Baz
         """)))
-        self.assertIn('foo', self.bundle._messages_and_terms)
-        self.assertIn('bar', self.bundle._messages_and_terms)
-        self.assertIn('-baz', self.bundle._messages_and_terms)
+        self.assertIn('foo', self.bundle._messages)
+        self.assertIn('bar', self.bundle._messages)
+        self.assertIn('baz', self.bundle._terms)
 
     def test_has_message(self):
         self.bundle.add_resource(FluentResource(dedent_ftl("""
@@ -80,15 +80,15 @@ class TestFluentBundle(unittest.TestCase):
 
     def test_format_args(self):
         self.bundle.add_resource(FluentResource('foo = Foo'))
-        val, errs = self.bundle.format('foo')
+        val, errs = self.bundle.format_pattern(self.bundle.get_message('foo').value)
         self.assertEqual(val, 'Foo')
 
-        val, errs = self.bundle.format('foo', {})
+        val, errs = self.bundle.format_pattern(self.bundle.get_message('foo').value, {})
         self.assertEqual(val, 'Foo')
 
     def test_format_missing(self):
         self.assertRaises(LookupError,
-                          self.bundle.format,
+                          self.bundle.get_message,
                           'a-missing-message')
 
     def test_format_term(self):
@@ -96,10 +96,10 @@ class TestFluentBundle(unittest.TestCase):
             -foo = Foo
         """)))
         self.assertRaises(LookupError,
-                          self.bundle.format,
+                          self.bundle.get_message,
                           '-foo')
         self.assertRaises(LookupError,
-                          self.bundle.format,
+                          self.bundle.get_message,
                           'foo')
 
     def test_message_and_term_separate(self):
@@ -107,6 +107,6 @@ class TestFluentBundle(unittest.TestCase):
             foo = Refers to { -foo }
             -foo = Foo
         """)))
-        val, errs = self.bundle.format('foo', {})
+        val, errs = self.bundle.format_pattern(self.bundle.get_message('foo').value, {})
         self.assertEqual(val, 'Refers to \u2068Foo\u2069')
         self.assertEqual(errs, [])

--- a/fluent.runtime/tests/test_bundle.py
+++ b/fluent.runtime/tests/test_bundle.py
@@ -3,110 +3,110 @@ from __future__ import absolute_import, unicode_literals
 
 import unittest
 
-from fluent.runtime import FluentBundle
+from fluent.runtime import FluentBundle, FluentResource
 
 from .utils import dedent_ftl
 
 
 class TestFluentBundle(unittest.TestCase):
     def setUp(self):
-        self.ctx = FluentBundle(['en-US'])
+        self.bundle = FluentBundle(['en-US'])
 
-    def test_add_messages(self):
-        self.ctx.add_messages(dedent_ftl("""
+    def test_add_resource(self):
+        self.bundle.add_resource(FluentResource(dedent_ftl("""
             foo = Foo
             bar = Bar
             -baz = Baz
-        """))
-        self.assertIn('foo', self.ctx._messages_and_terms)
-        self.assertIn('bar', self.ctx._messages_and_terms)
-        self.assertIn('-baz', self.ctx._messages_and_terms)
+        """)))
+        self.assertIn('foo', self.bundle._messages_and_terms)
+        self.assertIn('bar', self.bundle._messages_and_terms)
+        self.assertIn('-baz', self.bundle._messages_and_terms)
 
     def test_has_message(self):
-        self.ctx.add_messages(dedent_ftl("""
+        self.bundle.add_resource(FluentResource(dedent_ftl("""
             foo = Foo
-        """))
+        """)))
 
-        self.assertTrue(self.ctx.has_message('foo'))
-        self.assertFalse(self.ctx.has_message('bar'))
+        self.assertTrue(self.bundle.has_message('foo'))
+        self.assertFalse(self.bundle.has_message('bar'))
 
     def test_has_message_for_term(self):
-        self.ctx.add_messages(dedent_ftl("""
+        self.bundle.add_resource(FluentResource(dedent_ftl("""
             -foo = Foo
-        """))
+        """)))
 
-        self.assertFalse(self.ctx.has_message('-foo'))
+        self.assertFalse(self.bundle.has_message('-foo'))
 
     def test_has_message_with_attribute(self):
-        self.ctx.add_messages(dedent_ftl("""
+        self.bundle.add_resource(FluentResource(dedent_ftl("""
             foo = Foo
                 .attr = Foo Attribute
-        """))
+        """)))
 
-        self.assertTrue(self.ctx.has_message('foo'))
-        self.assertFalse(self.ctx.has_message('foo.attr'))
-        self.assertFalse(self.ctx.has_message('foo.other-attribute'))
+        self.assertTrue(self.bundle.has_message('foo'))
+        self.assertFalse(self.bundle.has_message('foo.attr'))
+        self.assertFalse(self.bundle.has_message('foo.other-attribute'))
 
     def test_plural_form_english_ints(self):
-        ctx = FluentBundle(['en-US'])
-        self.assertEqual(ctx._plural_form(0),
+        bundle = FluentBundle(['en-US'])
+        self.assertEqual(bundle._plural_form(0),
                          'other')
-        self.assertEqual(ctx._plural_form(1),
+        self.assertEqual(bundle._plural_form(1),
                          'one')
-        self.assertEqual(ctx._plural_form(2),
+        self.assertEqual(bundle._plural_form(2),
                          'other')
 
     def test_plural_form_english_floats(self):
-        ctx = FluentBundle(['en-US'])
-        self.assertEqual(ctx._plural_form(0.0),
+        bundle = FluentBundle(['en-US'])
+        self.assertEqual(bundle._plural_form(0.0),
                          'other')
-        self.assertEqual(ctx._plural_form(1.0),
+        self.assertEqual(bundle._plural_form(1.0),
                          'one')
-        self.assertEqual(ctx._plural_form(2.0),
+        self.assertEqual(bundle._plural_form(2.0),
                          'other')
-        self.assertEqual(ctx._plural_form(0.5),
+        self.assertEqual(bundle._plural_form(0.5),
                          'other')
 
     def test_plural_form_french(self):
         # Just spot check one other, to ensure that we
         # are not getting the EN locale by accident or
-        ctx = FluentBundle(['fr'])
-        self.assertEqual(ctx._plural_form(0),
+        bundle = FluentBundle(['fr'])
+        self.assertEqual(bundle._plural_form(0),
                          'one')
-        self.assertEqual(ctx._plural_form(1),
+        self.assertEqual(bundle._plural_form(1),
                          'one')
-        self.assertEqual(ctx._plural_form(2),
+        self.assertEqual(bundle._plural_form(2),
                          'other')
 
     def test_format_args(self):
-        self.ctx.add_messages('foo = Foo')
-        val, errs = self.ctx.format('foo')
+        self.bundle.add_resource(FluentResource('foo = Foo'))
+        val, errs = self.bundle.format('foo')
         self.assertEqual(val, 'Foo')
 
-        val, errs = self.ctx.format('foo', {})
+        val, errs = self.bundle.format('foo', {})
         self.assertEqual(val, 'Foo')
 
     def test_format_missing(self):
         self.assertRaises(LookupError,
-                          self.ctx.format,
+                          self.bundle.format,
                           'a-missing-message')
 
     def test_format_term(self):
-        self.ctx.add_messages(dedent_ftl("""
+        self.bundle.add_resource(FluentResource(dedent_ftl("""
             -foo = Foo
-        """))
+        """)))
         self.assertRaises(LookupError,
-                          self.ctx.format,
+                          self.bundle.format,
                           '-foo')
         self.assertRaises(LookupError,
-                          self.ctx.format,
+                          self.bundle.format,
                           'foo')
 
     def test_message_and_term_separate(self):
-        self.ctx.add_messages(dedent_ftl("""
+        self.bundle.add_resource(FluentResource(dedent_ftl("""
             foo = Refers to { -foo }
             -foo = Foo
-        """))
-        val, errs = self.ctx.format('foo', {})
+        """)))
+        val, errs = self.bundle.format('foo', {})
         self.assertEqual(val, 'Refers to \u2068Foo\u2069')
         self.assertEqual(errs, [])

--- a/fluent.runtime/tests/test_fallback.py
+++ b/fluent.runtime/tests/test_fallback.py
@@ -1,0 +1,95 @@
+# -*- coding: utf-8 -*-
+from __future__ import absolute_import, unicode_literals
+
+import unittest
+import mock
+import os
+import six
+
+from fluent.runtime import (
+    FluentLocalization,
+    FluentResourceLoader,
+)
+
+
+ISFILE = os.path.isfile
+
+
+class TestLocalization(unittest.TestCase):
+    def test_init(self):
+        l10n = FluentLocalization(
+            ['en'], ['file.ftl'], FluentResourceLoader('{locale}')
+        )
+        self.assertTrue(callable(l10n.format_value))
+
+    @mock.patch('os.path.isfile')
+    @mock.patch('codecs.open')
+    def test_bundles(self, codecs_open, isfile):
+        data = {
+            'de/one.ftl': 'one = in German',
+            'de/two.ftl': 'two = in German',
+            'fr/two.ftl': 'three = in French',
+            'en/one.ftl': 'four = exists',
+            'en/two.ftl': 'five = exists',
+        }
+        isfile.side_effect = lambda p: p in data or ISFILE(p)
+        codecs_open.side_effect = lambda p, _, __: six.StringIO(data[p])
+        l10n = FluentLocalization(
+            ['de', 'fr', 'en'],
+            ['one.ftl', 'two.ftl'],
+            FluentResourceLoader('{locale}')
+        )
+        bundles_gen = l10n._bundles()
+        bundle_de = next(bundles_gen)
+        self.assertEqual(bundle_de.locales[0], 'de')
+        self.assertTrue(bundle_de.has_message('one'))
+        self.assertTrue(bundle_de.has_message('two'))
+        bundle_fr = next(bundles_gen)
+        self.assertEqual(bundle_fr.locales[0], 'fr')
+        self.assertFalse(bundle_fr.has_message('one'))
+        self.assertTrue(bundle_fr.has_message('three'))
+        self.assertListEqual(list(l10n._bundles())[:2], [bundle_de, bundle_fr])
+        bundle_en = next(bundles_gen)
+        self.assertEqual(bundle_en.locales[0], 'en')
+        self.assertEqual(l10n.format_value('one'), 'in German')
+        self.assertEqual(l10n.format_value('two'), 'in German')
+        self.assertEqual(l10n.format_value('three'), 'in French')
+        self.assertEqual(l10n.format_value('four'), 'exists')
+        self.assertEqual(l10n.format_value('five'), 'exists')
+
+
+@mock.patch('os.path.isfile')
+@mock.patch('codecs.open')
+class TestResourceLoader(unittest.TestCase):
+    def test_all_exist(self, codecs_open, isfile):
+        data = {
+            'en/one.ftl': 'one = exists',
+            'en/two.ftl': 'two = exists',
+        }
+        isfile.side_effect = lambda p: p in data
+        codecs_open.side_effect = lambda p, _, __: six.StringIO(data[p])
+        loader = FluentResourceLoader('{locale}')
+        resources_list = list(loader.resources('en', ['one.ftl', 'two.ftl']))
+        self.assertEqual(len(resources_list), 1)
+        resources = resources_list[0]
+        self.assertEqual(len(resources), 2)
+
+    def test_one_exists(self, codecs_open, isfile):
+        data = {
+            'en/two.ftl': 'two = exists',
+        }
+        isfile.side_effect = lambda p: p in data
+        codecs_open.side_effect = lambda p, _, __: six.StringIO(data[p])
+        loader = FluentResourceLoader('{locale}')
+        resources_list = list(loader.resources('en', ['one.ftl', 'two.ftl']))
+        self.assertEqual(len(resources_list), 1)
+        resources = resources_list[0]
+        self.assertEqual(len(resources), 1)
+
+    def test_none_exist(self, codecs_open, isfile):
+        data = {}
+        isfile.side_effect = lambda p: p in data
+        codecs_open.side_effect = lambda p, _, __: six.StringIO(data[p])
+        loader = FluentResourceLoader('{locale}')
+        resources_list = list(loader.resources('en', ['one.ftl', 'two.ftl']))
+        self.assertEqual(len(resources_list), 0)

--- a/fluent.runtime/tools/benchmarks/fluent_benchmark.py
+++ b/fluent.runtime/tools/benchmarks/fluent_benchmark.py
@@ -33,16 +33,16 @@ def fluent_bundle():
 def fluent_template(bundle):
     return (
         "preface" +
-        bundle.format("one")[0] +
-        bundle.format("two")[0] +
-        bundle.format("three")[0] +
-        bundle.format("four")[0] +
-        bundle.format("five")[0] +
-        bundle.format("six")[0] +
-        bundle.format("seven", {"destination": "Mars"})[0] +
-        bundle.format("eight")[0] +
-        bundle.format("nine")[0] +
-        bundle.format("ten")[0] +
+        bundle.format_pattern(bundle.get_message('one').value)[0] +
+        bundle.format_pattern(bundle.get_message('two').value)[0] +
+        bundle.format_pattern(bundle.get_message('three').value)[0] +
+        bundle.format_pattern(bundle.get_message('four').value)[0] +
+        bundle.format_pattern(bundle.get_message('five').value)[0] +
+        bundle.format_pattern(bundle.get_message('six').value)[0] +
+        bundle.format_pattern(bundle.get_message('seven').value, {"destination": "Mars"})[0] +
+        bundle.format_pattern(bundle.get_message('eight').value)[0] +
+        bundle.format_pattern(bundle.get_message('nine').value)[0] +
+        bundle.format_pattern(bundle.get_message('ten').value)[0] +
         "tail"
     )
 

--- a/fluent.runtime/tools/benchmarks/fluent_benchmark.py
+++ b/fluent.runtime/tools/benchmarks/fluent_benchmark.py
@@ -7,7 +7,7 @@ import sys
 import pytest
 import six
 
-from fluent.runtime import FluentBundle
+from fluent.runtime import FluentBundle, FluentResource
 
 
 FTL_CONTENT = """
@@ -25,9 +25,9 @@ ten = Ten
 
 @pytest.fixture
 def fluent_bundle():
-    ctx = FluentBundle(['pl'], use_isolating=False)
-    ctx.add_messages(FTL_CONTENT)
-    return ctx
+    bundle = FluentBundle(['pl'], use_isolating=False)
+    bundle.add_resource(FluentResource(FTL_CONTENT))
+    return bundle
 
 
 def fluent_template(bundle):

--- a/fluent.runtime/tox.ini
+++ b/fluent.runtime/tox.ini
@@ -10,6 +10,7 @@ deps =
      syntax0.17: fluent.syntax==0.17
      attrs==19.1.0
      babel==2.7.0
+     mock==3.0.5
      pytz==2019.2
      six==1.12.0
 commands = ./runtests.py
@@ -25,4 +26,5 @@ deps =
      attrs
      babel
      pytz
+     mock
      six


### PR DESCRIPTION
This was an experimental branch to demonstrate how to implement the bundle API of other implementations, and to create a base Localization class for developers to use, and for binding-implementers to customize.

Per https://discourse.mozilla.org/t/experimental-release-of-python-fluent-runtime/47569/2, we should go ahead and merge this now.

CC @stasm @spookylukey 