### PR TITLE
fluent.syntax tests and linting on gh actions

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -26,7 +26,7 @@ jobs:
       - name: lint
         working-directory: ./fluent.syntax
         run: |
-          flake8 fluent
+          flake8
 
   runtime:
     name: flake8 runtime

--- a/.github/workflows/syntax-tests.yml
+++ b/.github/workflows/syntax-tests.yml
@@ -14,11 +14,14 @@ jobs:
   unit:
     name: Syntax unit tests
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: [2.7, 3.5, 3.6, 3.7, 3.8, pypy2, pypy3]
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-python@v2
         with:
-          python-version: 3.7
+          python-version: ${{ matrix.python-version }}
       - name: Install dependencies
         working-directory: ./fluent.syntax
         run: |

--- a/fluent.runtime/runtests.py
+++ b/fluent.runtime/runtests.py
@@ -25,6 +25,6 @@ else:
 if args.coverage:
     cmd = ["-m", "coverage", "run"] + cmd
 
-cmd.insert(0, "python")
+cmd.insert(0, sys.executable)
 
 sys.exit(subprocess.call(cmd))

--- a/fluent.syntax/setup.py
+++ b/fluent.syntax/setup.py
@@ -21,4 +21,4 @@ setup(name='fluent.syntax',
       # These should also be duplicated in tox.ini and ../.travis.yml
       tests_require=['six'],
       test_suite='tests.syntax'
-)
+      )

--- a/fluent.syntax/tests/syntax/test_ast_json.py
+++ b/fluent.syntax/tests/syntax/test_ast_json.py
@@ -1,8 +1,5 @@
 from __future__ import unicode_literals
 import unittest
-import sys
-
-sys.path.append('.')
 
 from tests.syntax import dedent_ftl
 from fluent.syntax.ast import from_json

--- a/fluent.syntax/tests/syntax/test_entry.py
+++ b/fluent.syntax/tests/syntax/test_entry.py
@@ -1,8 +1,5 @@
 from __future__ import unicode_literals
 import unittest
-import sys
-
-sys.path.append(".")
 
 from tests.syntax import dedent_ftl
 from fluent.syntax.ast import from_json
@@ -137,7 +134,6 @@ class TestParseEntry(unittest.TestCase):
 
         message = self.parser.parse_entry(dedent_ftl(input))
         self.assertEqual(message.to_json(), output)
-
 
     def test_do_not_ignore_invalid_comments(self):
         input = """\

--- a/fluent.syntax/tests/syntax/test_equals.py
+++ b/fluent.syntax/tests/syntax/test_equals.py
@@ -1,8 +1,5 @@
 from __future__ import unicode_literals
 import unittest
-import sys
-
-sys.path.append('.')
 
 from tests.syntax import dedent_ftl
 from fluent.syntax.parser import FluentParser

--- a/fluent.syntax/tests/syntax/test_reference.py
+++ b/fluent.syntax/tests/syntax/test_reference.py
@@ -2,14 +2,11 @@ from __future__ import unicode_literals
 from six import with_metaclass
 
 import os
-import sys
 import json
 import codecs
 import unittest
 
-sys.path.append('.')
-
-from fluent.syntax import parse, ast as ftl
+from fluent.syntax import parse
 
 
 def read_file(path):

--- a/fluent.syntax/tests/syntax/test_serializer.py
+++ b/fluent.syntax/tests/syntax/test_serializer.py
@@ -1,9 +1,7 @@
 from __future__ import unicode_literals
 import unittest
-import sys
 
-sys.path.append('.')
-
+import six
 from tests.syntax import dedent_ftl
 from fluent.syntax import FluentParser, FluentSerializer
 from fluent.syntax.serializer import serialize_expression, serialize_variant_key
@@ -20,10 +18,10 @@ class TestSerializeResource(unittest.TestCase):
     def test_invalid_resource(self):
         serializer = FluentSerializer()
 
-        with self.assertRaisesRegexp(Exception, 'Unknown resource type'):
+        with six.assertRaisesRegex(self, Exception, 'Unknown resource type'):
             serializer.serialize(None)
 
-        with self.assertRaisesRegexp(Exception, 'Unknown resource type'):
+        with six.assertRaisesRegex(self, Exception, 'Unknown resource type'):
             serializer.serialize(object())
 
     def test_simple_message(self):
@@ -430,10 +428,10 @@ class TestSerializeExpression(unittest.TestCase):
         return serialize_expression(expr)
 
     def test_invalid_expression(self):
-        with self.assertRaisesRegexp(Exception, 'Unknown expression type'):
+        with six.assertRaisesRegex(self, Exception, 'Unknown expression type'):
             serialize_expression(None)
 
-        with self.assertRaisesRegexp(Exception, 'Unknown expression type'):
+        with six.assertRaisesRegex(self, Exception, 'Unknown expression type'):
             serialize_expression(object())
 
     def test_string_expression(self):
@@ -491,10 +489,10 @@ class TestSerializeVariantKey(unittest.TestCase):
         return serialize_variant_key(variants[index].key)
 
     def test_invalid_expression(self):
-        with self.assertRaisesRegexp(Exception, 'Unknown variant key type'):
+        with six.assertRaisesRegex(self, Exception, 'Unknown variant key type'):
             serialize_variant_key(None)
 
-        with self.assertRaisesRegexp(Exception, 'Unknown variant key type'):
+        with six.assertRaisesRegex(self, Exception, 'Unknown variant key type'):
             serialize_variant_key(object())
 
     def test_identifiers(self):

--- a/fluent.syntax/tests/syntax/test_stream.py
+++ b/fluent.syntax/tests/syntax/test_stream.py
@@ -1,9 +1,7 @@
 import unittest
-import sys
-
-sys.path.append('.')
 
 from fluent.syntax.stream import ParserStream
+
 
 class TestParserStream(unittest.TestCase):
 
@@ -161,7 +159,3 @@ class TestParserStream(unittest.TestCase):
 
         self.assertEqual('d', ps.peek())
         self.assertEqual(None, ps.peek())
-
-
-if __name__ == '__main__':
-    unittest.main()

--- a/fluent.syntax/tests/syntax/test_structure.py
+++ b/fluent.syntax/tests/syntax/test_structure.py
@@ -2,12 +2,9 @@ from __future__ import unicode_literals
 from six import with_metaclass
 
 import os
-import sys
 import json
 import codecs
 import unittest
-
-sys.path.append('.')
 
 from fluent.syntax import parse
 

--- a/fluent.syntax/tests/syntax/test_visitor.py
+++ b/fluent.syntax/tests/syntax/test_visitor.py
@@ -76,10 +76,12 @@ class TestTransformer(unittest.TestCase):
 class WordCounter(object):
     def __init__(self):
         self.word_count = 0
+
     def __call__(self, node):
         if isinstance(node, ast.TextElement):
             self.word_count += len(node.value.split())
         return node
+
 
 class VisitorCounter(ast.Visitor):
     def __init__(self):
@@ -177,8 +179,7 @@ test.setUp()
     ]
 
 
-
-if __name__=='__main__':
+if __name__ == '__main__':
     for m in (
         'traverse',
         'visitor',


### PR DESCRIPTION
Making the test runner actually use the python you run it with.

Then, add gh-actions test automation.

As I saw a deprecation warning on master, I went in and fixed
the tests, including flake8.
And thus I switched on flake8 for all of fluent.syntax.