### PR TITLE
Automate fluent.runtime on gh actions

### DIFF
--- a/.github/workflows/fluent.runtime.yml
+++ b/.github/workflows/fluent.runtime.yml
@@ -1,0 +1,77 @@
+name: fluent.runtime
+
+on:
+  # Trigger the workflow on push or pull request,
+  # but only for the master branch
+  push:
+    branches:
+      - master
+  pull_request:
+    branches:
+      - master
+
+jobs:
+  unit:
+    name: unit tests
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: [2.7, 3.5, 3.6, 3.7, 3.8, pypy2, pypy3]
+        fluent-syntax: [0.17.0]
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-python@v2
+        with:
+          python-version: ${{ matrix.python-version }}
+      - name: Install dependencies
+        working-directory: ./fluent.runtime
+        run: |
+          python -m pip install wheel
+          python -m pip install --upgrade pip
+          python -m pip install fluent.syntax==${{ matrix.fluent-syntax }}
+          python -m pip install . mock
+      - name: Test
+        working-directory: ./fluent.runtime
+        run: |
+          ./runtests.py
+  integration:
+    name: unit tests
+    runs-on: ubuntu-latest
+    continue-on-error: true
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-python@v2
+        with:
+          python-version: 3.7
+      - name: Install dependencies
+        working-directory: ./fluent.runtime
+        run: |
+          python -m pip install wheel
+          python -m pip install --upgrade pip
+          python -m pip install . mock
+      - name: Install latest fluent.syntax
+        working-directory: ./fluent.syntax
+        run: |
+          python -m pip install .
+      - name: Test
+        working-directory: ./fluent.runtime
+        run: |
+          ./runtests.py
+
+  lint:
+    name: flake8
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-python@v2
+        with:
+          python-version: 3.7
+      - name: Install dependencies
+        run: |
+          python -m pip install wheel
+          python -m pip install --upgrade pip
+          python -m pip install flake8==3.7.9
+      - name: lint
+        working-directory: ./fluent.runtime
+        run: |
+          flake8 fluent

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -27,20 +27,3 @@ jobs:
         working-directory: ./fluent.syntax
         run: |
           flake8
-
-  runtime:
-    name: flake8 runtime
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-python@v2
-        with:
-          python-version: 3.7
-      - name: Install dependencies
-        run: |
-          python -m pip install --upgrade pip
-          pip install flake8==3.7.9
-      - name: lint
-        working-directory: ./fluent.runtime
-        run: |
-          flake8 fluent


### PR DESCRIPTION
Lesson learned, workflow bades go by workflow name.
Using one workflow for the runtime package.
Test the latest compat version of syntax against master, as
well as master syntax against master runtime. The latter is
OK to fail.

Move linter from lint workflow to runtime workflow.