### PR TITLE
Make gh actions only run when needed.

### DIFF
--- a/.github/workflows/fluent.integration.yml
+++ b/.github/workflows/fluent.integration.yml
@@ -1,0 +1,44 @@
+name: integrations
+
+on:
+  # Trigger the workflow on push or pull request,
+  # but only for the master branch
+  push:
+    branches:
+      - master
+    paths:
+      - .github/workflows/fluent.integration.yml
+      - fluent.syntax/**.py
+      - fluent.runtime/**.py
+  pull_request:
+    branches:
+      - master
+    paths:
+      - .github/workflows/fluent.integration.yml
+      - fluent.syntax/**.py
+      - fluent.runtime/**.py
+
+jobs:
+  integration:
+    name: fluent.runtime
+    runs-on: ubuntu-latest
+    continue-on-error: true
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-python@v2
+        with:
+          python-version: 3.7
+      - name: Install dependencies
+        working-directory: ./fluent.runtime
+        run: |
+          python -m pip install wheel
+          python -m pip install --upgrade pip
+          python -m pip install . mock
+      - name: Install latest fluent.syntax
+        working-directory: ./fluent.syntax
+        run: |
+          python -m pip install .
+      - name: Test
+        working-directory: ./fluent.runtime
+        run: |
+          ./runtests.py

--- a/.github/workflows/fluent.runtime.yml
+++ b/.github/workflows/fluent.runtime.yml
@@ -6,9 +6,15 @@ on:
   push:
     branches:
       - master
+    paths:
+      - .github/workflows/fluent.runtime.yml
+      - fluent.runtime/**.py
   pull_request:
     branches:
       - master
+    paths:
+      - .github/workflows/fluent.runtime.yml
+      - fluent.runtime/**.py
 
 jobs:
   unit:
@@ -34,30 +40,6 @@ jobs:
         working-directory: ./fluent.runtime
         run: |
           ./runtests.py
-  integration:
-    name: unit tests
-    runs-on: ubuntu-latest
-    continue-on-error: true
-    steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-python@v2
-        with:
-          python-version: 3.7
-      - name: Install dependencies
-        working-directory: ./fluent.runtime
-        run: |
-          python -m pip install wheel
-          python -m pip install --upgrade pip
-          python -m pip install . mock
-      - name: Install latest fluent.syntax
-        working-directory: ./fluent.syntax
-        run: |
-          python -m pip install .
-      - name: Test
-        working-directory: ./fluent.runtime
-        run: |
-          ./runtests.py
-
   lint:
     name: flake8
     runs-on: ubuntu-latest

--- a/.github/workflows/fluent.syntax.yml
+++ b/.github/workflows/fluent.syntax.yml
@@ -6,13 +6,19 @@ on:
   push:
     branches:
       - master
+    paths:
+      - .github/workflows/fluent.syntax.yml
+      - fluent.syntax/**.py
   pull_request:
     branches:
       - master
+    paths:
+      - .github/workflows/fluent.syntax.yml
+      - fluent.syntax/**.py
 
 jobs:
   unit:
-    name: Syntax unit tests
+    name: unit tests
     runs-on: ubuntu-latest
     strategy:
       matrix:


### PR DESCRIPTION
This factors the integration jobs back into its own workflow.
This is to allow for the pygments module to also have integration
tests, and we're ignoring them for status (and thus badges)
anyway.