### PR TITLE
Build top-level, syntax, and runtime documentation from one config

### DIFF
--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -34,7 +34,7 @@ jobs:
         run: |
           ./scripts/build-docs --to-publish python-fluent
       - name: artifact
-        uses: actions/upload-artifact@v1
+        uses: actions/upload-artifact@v2
         with:
           name: html
           path: _build/python-fluent

--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -29,7 +29,7 @@ jobs:
           python-version: 3.7
       - name: Install dependencies
         run: |
-          pip install Sphinx
+          pip install Sphinx fluent.pygments
       - name: sphinx-build
         run: |
           ./scripts/build-docs --to-publish python-fluent

--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -1,0 +1,40 @@
+name: documentation
+
+on:
+  # Trigger the workflow on push or pull request,
+  # but only for the master branch
+  push:
+    branches:
+      - master
+    paths:
+      - docs/**
+      - fluent.*/docs/**
+      - fluent.*/setup.cfg
+  pull_request:
+    branches:
+      - master
+    paths:
+      - docs/**
+      - fluent.*/docs/**
+      - fluent.*/setup.cfg
+
+jobs:
+  build:
+    name: build
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-python@v2
+        with:
+          python-version: 3.7
+      - name: Install dependencies
+        run: |
+          pip install Sphinx
+      - name: sphinx-build
+        run: |
+          ./scripts/build-docs --to-publish python-fluent
+      - name: artifact
+        uses: actions/upload-artifact@v1
+        with:
+          name: html
+          path: _build/python-fluent

--- a/docs/Makefile
+++ b/docs/Makefile
@@ -1,0 +1,20 @@
+# Minimal makefile for Sphinx documentation
+#
+
+# You can set these variables from the command line, and also
+# from the environment for the first two.
+SPHINXOPTS    ?=
+SPHINXBUILD   ?= sphinx-build
+SOURCEDIR     = .
+BUILDDIR      = _build
+
+# Put it first so that "make" without argument is like "make help".
+help:
+	@$(SPHINXBUILD) -M help "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O)
+
+.PHONY: help Makefile
+
+# Catch-all target: route all unknown targets to Sphinx using the new
+# "make mode" option.  $(O) is meant as a shortcut for $(SPHINXOPTS).
+%: Makefile
+	@$(SPHINXBUILD) -M $@ "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O)

--- a/docs/_static/project-fluent.css
+++ b/docs/_static/project-fluent.css
@@ -1,0 +1,3 @@
+div.related {
+    background-color: #356eb7;
+}

--- a/docs/_templates/layout.html
+++ b/docs/_templates/layout.html
@@ -1,0 +1,22 @@
+{% extends "!layout.html" %}
+
+{%- block css %}
+    <link rel="stylesheet" href="{{ root_url + '/_static/' + style|e }}" type="text/css" />
+    <link rel="stylesheet" href="{{ root_url + '/_static/pygments.css' }}" type="text/css" />
+    {%- for css in css_files %}
+    <link rel="stylesheet" href="{{ root_url + '/' + css|e }}" type="text/css" />
+    {%- endfor %}
+{%- endblock %}
+
+{%- block scripts %}
+    <script id="documentation_options" data-url_root="{{ pathto('', 1) }}" src="{{ pathto('_static/documentation_options.js', 1) }}"></script>
+    {%- for js in script_files %}
+    <script src="{{root_url}}/{{js}}"></script>
+    {%- endfor %}
+{%- endblock %}
+
+{%- block footer %}
+    <div class="footer" role="contentinfo">
+        python-fluent documentation is licensed under the APL 2.0.
+    </div>
+{%- endblock %}

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -53,6 +53,11 @@ html_theme = 'nature'
 html_static_path = ['_static']
 html_css_files = ['project-fluent.css']
 
+html_sidebars = {
+    '**': ['globaltoc.html', 'searchbox.html'],
+}
+html_theme_options = {
+}
 
 # -- Extension configuration -------------------------------------------------
 
@@ -65,3 +70,4 @@ intersphinx_mapping = {}
 autodoc_mock_imports = [
      'attr',
 ]
+autodoc_member_order = 'bysource'

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -1,0 +1,67 @@
+# Configuration file for the Sphinx documentation builder.
+#
+# This file only contains a selection of the most common options. For a full
+# list see the documentation:
+# https://www.sphinx-doc.org/en/master/usage/configuration.html
+
+# -- Path setup --------------------------------------------------------------
+
+# If extensions (or modules to document with autodoc) are in another directory,
+# add these directories to sys.path here. If the directory is relative to the
+# documentation root, use os.path.abspath to make it absolute, like shown here.
+#
+# import os
+# import sys
+# sys.path.insert(0, os.path.abspath('.'))
+
+
+# -- Project information -----------------------------------------------------
+
+project = 'python-fluent'
+
+
+# -- General configuration ---------------------------------------------------
+
+# Add any Sphinx extension module names here, as strings. They can be
+# extensions coming with Sphinx (named 'sphinx.ext.*') or your custom
+# ones.
+extensions = [
+    'sphinx.ext.intersphinx',
+    'sphinx.ext.viewcode',
+    'sphinx.ext.autodoc',
+]
+
+# Add any paths that contain templates here, relative to this directory.
+templates_path = ['_templates']
+
+# List of patterns, relative to source directory, that match files and
+# directories to ignore when looking for source files.
+# This pattern also affects html_static_path and html_extra_path.
+exclude_patterns = ['_build', 'Thumbs.db', '.DS_Store']
+
+
+# -- Options for HTML output -------------------------------------------------
+
+# The theme to use for HTML and HTML Help pages.  See the documentation for
+# a list of builtin themes.
+#
+html_theme = 'nature'
+
+# Add any paths that contain custom static files (such as style sheets) here,
+# relative to this directory. They are copied after the builtin static files,
+# so a file named "default.css" will overwrite the builtin "default.css".
+html_static_path = ['_static']
+html_css_files = ['project-fluent.css']
+
+
+# -- Extension configuration -------------------------------------------------
+
+# -- Options for intersphinx extension ---------------------------------------
+
+# Example configuration for intersphinx: refer to the Python standard library.
+intersphinx_mapping = {}
+
+# -- Options for autodoc extension --------------------------------------------
+autodoc_mock_imports = [
+     'attr',
+]

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -1,0 +1,7 @@
+
+Welcome to Python Fluent's documentation!
+=========================================
+
+The :py:mod:`python-fluent` library contains a
+`syntax <fluent.syntax/stable/>`_ and a
+`runtime <fluent.runtime/stable/>`_ library.

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -1,7 +1,28 @@
 
-Welcome to Python Fluent's documentation!
-=========================================
+python-fluent
+=============
 
-The :py:mod:`python-fluent` library contains a
-`syntax <fluent.syntax/stable/>`_ and a
-`runtime <fluent.runtime/stable/>`_ library.
+The :py:mod:`python-fluent` project contains several packages to
+bring `Project Fluent <https://projectfluent.org>`__ to Python.
+Visit the `Github project <https://github.com/projectfluent/python-fluent>`__
+for the full list. Two packages in particular are of general interest
+and documented here.
+
+fluent.syntax
+-------------
+
+``fluent-syntax`` is the package to use for tooling, analysis, and
+processing of Fluent files.
+
+fluent.runtime
+--------------
+
+``fluent-runtime`` is the reference runtime implementation for
+Fluent in Python.
+
+.. toctree::
+   :caption: Packages
+   :maxdepth: 1
+
+   fluent.syntax <https://projectfluent.org/python-fluent/fluent.syntax/>
+   fluent.runtime <https://projectfluent.org/python-fluent/fluent.runtime/>

--- a/fluent.runtime/docs/index.rst
+++ b/fluent.runtime/docs/index.rst
@@ -10,7 +10,7 @@ These are the docs for ``fluent.runtime`` |release|. Check the :doc:`/history` f
 significant changes.
 
 .. toctree::
-   :maxdepth: 2
+   :maxdepth: 1
    :caption: Contents:
 
    installation

--- a/fluent.runtime/setup.cfg
+++ b/fluent.runtime/setup.cfg
@@ -1,3 +1,6 @@
+[metadata]
+version=0.3
+
 [bdist_wheel]
 universal=1
 

--- a/fluent.runtime/setup.py
+++ b/fluent.runtime/setup.py
@@ -3,7 +3,6 @@ from setuptools import setup
 
 
 setup(name='fluent.runtime',
-      version='0.3',
       description='Localization library for expressive translations.',
       long_description='See https://github.com/projectfluent/python-fluent/ for more info.',
       author='Luke Plant',

--- a/fluent.syntax/setup.cfg
+++ b/fluent.syntax/setup.cfg
@@ -1,3 +1,6 @@
+[metadata]
+version=0.17.0
+
 [bdist_wheel]
 universal=1
 

--- a/fluent.syntax/setup.py
+++ b/fluent.syntax/setup.py
@@ -2,7 +2,6 @@
 from setuptools import setup
 
 setup(name='fluent.syntax',
-      version='0.17.0',
       description='Localization library for expressive translations.',
       long_description='See https://github.com/projectfluent/python-fluent/ for more info.',
       author='Mozilla',

--- a/scripts/build-docs
+++ b/scripts/build-docs
@@ -1,21 +1,24 @@
 #!/usr/bin/env python3
 
 import argparse
+from configparser import ConfigParser
 import os
 from pathlib import Path
 import subprocess
 
 
-VERSIONS = {
-    'fluent.syntax': '0.17.0',
-    'fluent.runtime': '0.3.0',
-}
+def get_version(root):
+    if root == '.':
+        return
+    cp = ConfigParser()
+    cp.read(Path(root) / 'setup.cfg')
+    return cp.get('metadata', 'version')
 
 
 def build(repo_name, doc_roots):
     for doc_root in doc_roots:
         env = os.environ.copy()
-        version = VERSIONS.get(doc_root)
+        version = get_version(doc_root)
         cmd = [
             'sphinx-build',
             '-c', 'docs',

--- a/scripts/build-docs
+++ b/scripts/build-docs
@@ -2,6 +2,7 @@
 
 import argparse
 import os
+from pathlib import Path
 import subprocess
 
 
@@ -20,6 +21,7 @@ def build(repo_name, doc_roots):
             '-c', 'docs',
             '-a', '-E', '-W',
             '-A', 'root_url=/' + repo_name,
+            '-d', '_build/doctrees/' + doc_root,
         ]
         if version:
             env['PYTHONPATH'] = doc_root
@@ -40,12 +42,38 @@ def build(repo_name, doc_roots):
                 index.write('<meta http-equiv="refresh" content="0; URL=stable/">\n')
 
 
+def pre_pub(repo_name):
+    """Prepare staging area for publishing on Github pages."""
+    root = Path('_build') / repo_name
+    # Ensure `.nojekyll`
+    with open(root / '.nojekyll', 'w') as fh:
+        fh.write('')
+    # Remove static files from subprojects, but leave
+    # `documentation_options.js` alone. That's per project, probably.
+    # We built to root/fluent.*/stable, so glob that.
+    for staticfile in root.glob('fluent.*/stable/_static/*'):
+        if staticfile.name != 'documentation_options.js':
+            staticfile.unlink()
+
+
 if __name__ == "__main__":
     parser = argparse.ArgumentParser()
-    parser.add_argument('repo_name')
+    parser.add_argument(
+        'repo_name',
+        help='URL prefix on the web. Repo name on gh-pages'
+    )
+    parser.add_argument(
+        '--to-publish', dest='pre_pub', action='store_true',
+        help='Use this to publish to Github. Builds faster without.'
+    )
     default_docs = ['.', 'fluent.syntax', 'fluent.runtime']
-    parser.add_argument('--doc', action='append', choices=default_docs)
+    parser.add_argument(
+        '--doc', action='append', choices=default_docs,
+        help='Only build select documentation roots.'
+    )
     args = parser.parse_args()
     if args.doc is None:
         args.doc = default_docs
     build(args.repo_name, args.doc)
+    if args.pre_pub:
+        pre_pub(args.repo_name)

--- a/scripts/build-docs
+++ b/scripts/build-docs
@@ -11,14 +11,14 @@ VERSIONS = {
 }
 
 
-def main(repo_name):
-    for doc_root in ('.', 'fluent.syntax', 'fluent.runtime'):
+def build(repo_name, doc_roots):
+    for doc_root in doc_roots:
         env = os.environ.copy()
         version = VERSIONS.get(doc_root)
         cmd = [
             'sphinx-build',
             '-c', 'docs',
-            '-a', '-E',
+            '-a', '-E', '-W',
             '-A', 'root_url=/' + repo_name,
         ]
         if version:
@@ -43,5 +43,9 @@ def main(repo_name):
 if __name__ == "__main__":
     parser = argparse.ArgumentParser()
     parser.add_argument('repo_name')
+    default_docs = ['.', 'fluent.syntax', 'fluent.runtime']
+    parser.add_argument('--doc', action='append', choices=default_docs)
     args = parser.parse_args()
-    main(args.repo_name)
+    if args.doc is None:
+        args.doc = default_docs
+    build(args.repo_name, args.doc)

--- a/scripts/build-docs
+++ b/scripts/build-docs
@@ -1,0 +1,47 @@
+#!/usr/bin/env python3
+
+import argparse
+import os
+import subprocess
+
+
+VERSIONS = {
+    'fluent.syntax': '0.17.0',
+    'fluent.runtime': '0.3.0',
+}
+
+
+def main(repo_name):
+    for doc_root in ('.', 'fluent.syntax', 'fluent.runtime'):
+        env = os.environ.copy()
+        version = VERSIONS.get(doc_root)
+        cmd = [
+            'sphinx-build',
+            '-c', 'docs',
+            '-a', '-E',
+            '-A', 'root_url=/' + repo_name,
+        ]
+        if version:
+            env['PYTHONPATH'] = doc_root
+            cmd += [
+                '-D', 'release=' + version,
+                '-D', 'project=' + doc_root,
+            ]
+            build_dir = '_build/' + repo_name + '/' + doc_root + '/stable'
+        else:
+            build_dir = '_build/' + repo_name
+        cmd += [
+            doc_root + '/docs',
+            build_dir,
+        ]
+        subprocess.check_call(' '.join(cmd), env=env, shell=True)
+        if build_dir.endswith('/stable'):
+            with open(build_dir.replace('/stable', '/index.html'), 'w') as index:
+                index.write('<meta http-equiv="refresh" content="0; URL=stable/">\n')
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser()
+    parser.add_argument('repo_name')
+    args = parser.parse_args()
+    main(args.repo_name)


### PR DESCRIPTION
This builds and hosts, if you use the following mammoth to rsync to a repo with gh-pages:

```
rsync -rav --include='**/_static/documentation_options.js' --exclude='fluent.*/**/_static/*' --exclude='.*' _build/python-fluent/ ....
```

The docs are generated via a script, `./scripts/build-docs python-fluent`.