### PR TITLE
Copy fluent.runtime/runtests.py to fluent.syntax

### DIFF
--- a/fluent.runtime/runtests.py
+++ b/fluent.runtime/runtests.py
@@ -1,7 +1,5 @@
 #!/usr/bin/env python
 
-# This file is symlinked from both fluent.runtime and fluent.syntax directories
-
 import argparse
 import subprocess
 import sys

--- a/fluent.syntax/runtests.py
+++ b/fluent.syntax/runtests.py
@@ -1,1 +1,28 @@
-../fluent.runtime/runtests.py
+#!/usr/bin/env python
+
+import argparse
+import subprocess
+import sys
+
+parser = argparse.ArgumentParser(
+    description="Run the test suite, or some tests")
+parser.add_argument('--coverage', "-c", action='store_true',
+                    help="Run with 'coverage'")
+parser.add_argument('test', type=str, nargs="*",
+                    help="Dotted path to a test module, case or method")
+
+args = parser.parse_args()
+
+cmd = ["-m", "unittest"]
+
+if args.test:
+    cmd.extend(args.test)
+else:
+    cmd.extend(["discover", "-t", ".", "-s", "tests"])
+
+if args.coverage:
+    cmd = ["-m", "coverage", "run"] + cmd
+
+cmd.insert(0, sys.executable)
+
+sys.exit(subprocess.call(cmd))


### PR DESCRIPTION
VS Code doesn't like the fact that `fluent.syntax/runtests.py` looks like a Bash script (it's a symlink) rather than a Python script as the extension would suggest.