### PR TITLE
Rename default branch as main

### DIFF
--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -3,10 +3,10 @@ name: documentation
 on:
   workflow_dispatch:
   # Trigger the workflow on push or pull request,
-  # but only for the master branch
+  # but only for the main branch
   push:
     branches:
-      - master
+      - main
     paths:
       - docs/**
       - fluent.*/docs/**
@@ -14,7 +14,7 @@ on:
       - fluent.*/setup.cfg
   pull_request:
     branches:
-      - master
+      - main
     paths:
       - docs/**
       - fluent.*/docs/**

--- a/.github/workflows/fluent.integration.yml
+++ b/.github/workflows/fluent.integration.yml
@@ -2,10 +2,10 @@ name: integrations
 
 on:
   # Trigger the workflow on push or pull request,
-  # but only for the master branch
+  # but only for the main branch
   push:
     branches:
-      - master
+      - main
     paths:
       - .github/workflows/fluent.integration.yml
       - "fluent.syntax/**"
@@ -14,7 +14,7 @@ on:
       - "!fluent.runtime/docs/**"
   pull_request:
     branches:
-      - master
+      - main
     paths:
       - .github/workflows/fluent.integration.yml
       - "fluent.syntax/**"

--- a/.github/workflows/fluent.runtime.yml
+++ b/.github/workflows/fluent.runtime.yml
@@ -2,17 +2,17 @@ name: fluent.runtime
 
 on:
   # Trigger the workflow on push or pull request,
-  # but only for the master branch
+  # but only for the main branch
   push:
     branches:
-      - master
+      - main
     paths:
       - .github/workflows/fluent.runtime.yml
       - "fluent.runtime/**"
       - "!fluent.runtime/docs/**"
   pull_request:
     branches:
-      - master
+      - main
     paths:
       - .github/workflows/fluent.runtime.yml
       - "fluent.runtime/**"

--- a/.github/workflows/fluent.syntax.yml
+++ b/.github/workflows/fluent.syntax.yml
@@ -2,17 +2,17 @@ name: fluent.syntax
 
 on:
   # Trigger the workflow on push or pull request,
-  # but only for the master branch
+  # but only for the main branch
   push:
     branches:
-      - master
+      - main
     paths:
       - .github/workflows/fluent.syntax.yml
       - "fluent.syntax/**"
       - "!fluent.syntax/docs/**"
   pull_request:
     branches:
-      - master
+      - main
     paths:
       - .github/workflows/fluent.syntax.yml
       - "fluent.syntax/**"

--- a/fluent.docs/README.rst
+++ b/fluent.docs/README.rst
@@ -9,7 +9,7 @@ can surf it locally via ``python3 -m http.server `` in ``_build``.
 
 The documentation is created for each tagged version after May 2020,
 at which point we had good docs. The current branch (PR tips or
-master) is versioned as *dev*, and *stable* is a symlink to the latest
+main) is versioned as *dev*, and *stable* is a symlink to the latest
 release. The releases are in a dir with their corresponding version number.
 
 When cutting a new release, manually run the documentation workflow


### PR DESCRIPTION
These changes should go together with the actual rename of the default branch, which should be pretty painless.