### PR TITLE
Treat tab as text, not whitespace

### DIFF
--- a/fluent.syntax/fluent/syntax/parser.py
+++ b/fluent.syntax/fluent/syntax/parser.py
@@ -439,7 +439,7 @@ class FluentParser:
         # Trim trailing whitespace from the Pattern.
         last_element = trimmed[-1] if len(trimmed) > 0 else None
         if isinstance(last_element, ast.TextElement):
-            last_element.value = last_element.value.rstrip(' \t\n\r')
+            last_element.value = last_element.value.rstrip(' \n\r')
             if last_element.value == "":
                 trimmed.pop()
 

--- a/fluent.syntax/tests/syntax/fixtures_reference/tab.ftl
+++ b/fluent.syntax/tests/syntax/fixtures_reference/tab.ftl
@@ -12,3 +12,10 @@ key03 =
 key04 =
     This line is indented by 4 spaces,
 	whereas this line by 1 tab.
+
+# OK (value is a single tab)
+key05 = 	
+
+# OK (attribute value is two tabs)
+key06 =
+  .attr = 		

--- a/fluent.syntax/tests/syntax/fixtures_reference/tab.json
+++ b/fluent.syntax/tests/syntax/fixtures_reference/tab.json
@@ -64,7 +64,58 @@
         {
             "type": "Junk",
             "annotations": [],
-            "content": "\twhereas this line by 1 tab.\n"
+            "content": "\twhereas this line by 1 tab.\n\n"
+        },
+        {
+            "type": "Message",
+            "id": {
+                "type": "Identifier",
+                "name": "key05"
+            },
+            "value": {
+                "type": "Pattern",
+                "elements": [
+                    {
+                        "type": "TextElement",
+                        "value": "\t"
+                    }
+                ]
+            },
+            "attributes": [],
+            "comment": {
+                "type": "Comment",
+                "content": "OK (value is a single tab)"
+            }
+        },
+        {
+            "type": "Message",
+            "id": {
+                "type": "Identifier",
+                "name": "key06"
+            },
+            "value": null,
+            "attributes": [
+                {
+                    "type": "Attribute",
+                    "id": {
+                        "type": "Identifier",
+                        "name": "attr"
+                    },
+                    "value": {
+                        "type": "Pattern",
+                        "elements": [
+                            {
+                                "type": "TextElement",
+                                "value": "\t\t"
+                            }
+                        ]
+                    }
+                }
+            ],
+            "comment": {
+                "type": "Comment",
+                "content": "OK (attribute value is two tabs)"
+            }
         }
     ]
 }


### PR DESCRIPTION
Fixes #173 

Tabs were defined to be text, not whitespace, in projectfluent/fluent#167, but this change was not reflected in the trailing whitespace trimming.