### PR TITLE
Add type hints to fluent.syntax & fluent.runtime

### DIFF
--- a/.github/workflows/fluent.runtime.yml
+++ b/.github/workflows/fluent.runtime.yml
@@ -46,7 +46,6 @@ jobs:
         run: |
           ./runtests.py
   lint:
-    name: flake8
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
@@ -54,11 +53,21 @@ jobs:
         with:
           python-version: 3.9
       - name: Install dependencies
+        working-directory: ./fluent.runtime
         run: |
           python -m pip install wheel
           python -m pip install --upgrade pip
-          python -m pip install flake8==6
-      - name: lint
+          python -m pip install .
+          python -m pip install flake8==6 mypy==1 types-babel types-pytz
+      - name: Install latest fluent.syntax
+        working-directory: ./fluent.syntax
+        run: |
+          python -m pip install .
+      - name: flake8
         working-directory: ./fluent.runtime
         run: |
           python -m flake8
+      - name: mypy
+        working-directory: ./fluent.runtime
+        run: |
+          python -m mypy fluent/

--- a/.github/workflows/fluent.runtime.yml
+++ b/.github/workflows/fluent.runtime.yml
@@ -39,7 +39,7 @@ jobs:
         run: |
           python -m pip install wheel
           python -m pip install --upgrade pip
-          python -m pip install fluent.syntax==${{ matrix.fluent-syntax }}
+          python -m pip install fluent.syntax==${{ matrix.fluent-syntax }} six
           python -m pip install .
       - name: Test
         working-directory: ./fluent.runtime

--- a/.github/workflows/fluent.syntax.yml
+++ b/.github/workflows/fluent.syntax.yml
@@ -35,6 +35,7 @@ jobs:
         run: |
           python -m pip install wheel
           python -m pip install --upgrade pip
+          python -m pip install .
       - name: Test
         working-directory: ./fluent.syntax
         run: |

--- a/.github/workflows/fluent.syntax.yml
+++ b/.github/workflows/fluent.syntax.yml
@@ -39,8 +39,7 @@ jobs:
         working-directory: ./fluent.syntax
         run: |
           ./runtests.py
-  syntax:
-    name: flake8
+  lint:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
@@ -48,10 +47,16 @@ jobs:
         with:
           python-version: 3.9
       - name: Install dependencies
+        working-directory: ./fluent.syntax
         run: |
           python -m pip install --upgrade pip
-          python -m pip install flake8==6
-      - name: lint
+          python -m pip install .
+          python -m pip install flake8==6 mypy==1
+      - name: flake8
         working-directory: ./fluent.syntax
         run: |
           python -m flake8
+      - name: mypy
+        working-directory: ./fluent.syntax
+        run: |
+          python -m mypy fluent/

--- a/fluent.docs/setup.py
+++ b/fluent.docs/setup.py
@@ -1,6 +1,9 @@
-from setuptools import setup, find_namespace_packages
+from setuptools import setup
 
 setup(
     name='fluent.docs',
-    packages=find_namespace_packages(include=['fluent.*']),
+    packages=['fluent.docs'],
+    install_requires=[
+        'typing-extensions>=3.7,<5'
+    ],
 )

--- a/fluent.runtime/fluent/runtime/__init__.py
+++ b/fluent.runtime/fluent/runtime/__init__.py
@@ -1,14 +1,6 @@
-import babel
-import babel.numbers
-import babel.plural
-
 from fluent.syntax import FluentParser
-from fluent.syntax.ast import Message, Term
 
-from .builtins import BUILTINS
-from .prepare import Compiler
-from .resolver import ResolverEnvironment, CurrentEnvironment
-from .utils import native_to_fluent
+from .bundle import FluentBundle
 from .fallback import FluentLocalization, AbstractResourceLoader, FluentResourceLoader
 
 
@@ -24,91 +16,3 @@ __all__ = [
 def FluentResource(source):
     parser = FluentParser()
     return parser.parse(source)
-
-
-class FluentBundle:
-    """
-    Bundles are single-language stores of translations.  They are
-    aggregate parsed Fluent resources in the Fluent syntax and can
-    format translation units (entities) to strings.
-
-    Always use `FluentBundle.get_message` to retrieve translation units from
-    a bundle. Generate the localized string by using `format_pattern` on
-    `message.value` or `message.attributes['attr']`.
-    Translations can contain references to other entities or
-    external arguments, conditional logic in form of select expressions, traits
-    which describe their grammatical features, and can use Fluent builtins.
-    See the documentation of the Fluent syntax for more information.
-    """
-
-    def __init__(self, locales, functions=None, use_isolating=True):
-        self.locales = locales
-        _functions = BUILTINS.copy()
-        if functions:
-            _functions.update(functions)
-        self._functions = _functions
-        self.use_isolating = use_isolating
-        self._messages = {}
-        self._terms = {}
-        self._compiled = {}
-        self._compiler = Compiler()
-        self._babel_locale = self._get_babel_locale()
-        self._plural_form = babel.plural.to_python(self._babel_locale.plural_form)
-
-    def add_resource(self, resource, allow_overrides=False):
-        # TODO - warn/error about duplicates
-        for item in resource.body:
-            if not isinstance(item, (Message, Term)):
-                continue
-            map_ = self._messages if isinstance(item, Message) else self._terms
-            full_id = item.id.name
-            if full_id not in map_ or allow_overrides:
-                map_[full_id] = item
-
-    def has_message(self, message_id):
-        return message_id in self._messages
-
-    def get_message(self, message_id):
-        return self._lookup(message_id)
-
-    def _lookup(self, entry_id, term=False):
-        if term:
-            compiled_id = '-' + entry_id
-        else:
-            compiled_id = entry_id
-        try:
-            return self._compiled[compiled_id]
-        except LookupError:
-            pass
-        entry = self._terms[entry_id] if term else self._messages[entry_id]
-        self._compiled[compiled_id] = self._compiler(entry)
-        return self._compiled[compiled_id]
-
-    def format_pattern(self, pattern, args=None):
-        if args is not None:
-            fluent_args = {
-                argname: native_to_fluent(argvalue)
-                for argname, argvalue in args.items()
-            }
-        else:
-            fluent_args = {}
-
-        errors = []
-        env = ResolverEnvironment(context=self,
-                                  current=CurrentEnvironment(args=fluent_args),
-                                  errors=errors)
-        try:
-            result = pattern(env)
-        except ValueError as e:
-            errors.append(e)
-            result = '{???}'
-        return [result, errors]
-
-    def _get_babel_locale(self):
-        for lc in self.locales:
-            try:
-                return babel.Locale.parse(lc.replace('-', '_'))
-            except babel.UnknownLocaleError:
-                continue
-        # TODO - log error
-        return babel.Locale.default()

--- a/fluent.runtime/fluent/runtime/__init__.py
+++ b/fluent.runtime/fluent/runtime/__init__.py
@@ -1,4 +1,5 @@
 from fluent.syntax import FluentParser
+from fluent.syntax.ast import Resource
 
 from .bundle import FluentBundle
 from .fallback import FluentLocalization, AbstractResourceLoader, FluentResourceLoader
@@ -13,6 +14,6 @@ __all__ = [
 ]
 
 
-def FluentResource(source):
+def FluentResource(source: str) -> Resource:
     parser = FluentParser()
     return parser.parse(source)

--- a/fluent.runtime/fluent/runtime/builtins.py
+++ b/fluent.runtime/fluent/runtime/builtins.py
@@ -1,10 +1,11 @@
-from .types import fluent_date, fluent_number
+from typing import Any, Callable, Dict
+from .types import FluentType, fluent_date, fluent_number
 
 NUMBER = fluent_number
 DATETIME = fluent_date
 
 
-BUILTINS = {
+BUILTINS: Dict[str, Callable[[Any], FluentType]] = {
     'NUMBER': NUMBER,
     'DATETIME': DATETIME,
 }

--- a/fluent.runtime/fluent/runtime/bundle.py
+++ b/fluent.runtime/fluent/runtime/bundle.py
@@ -37,10 +37,7 @@ class FluentBundle:
                  functions: Union[Dict[str, Callable[[Any], 'FluentType']], None] = None,
                  use_isolating: bool = True):
         self.locales = locales
-        _functions = BUILTINS.copy()
-        if functions:
-            _functions.update(functions)
-        self._functions = _functions
+        self._functions = {**BUILTINS, **(functions or {})}
         self.use_isolating = use_isolating
         self._messages: Dict[str, Union[FTL.Message, FTL.Term]] = {}
         self._terms: Dict[str, Union[FTL.Message, FTL.Term]] = {}

--- a/fluent.runtime/fluent/runtime/bundle.py
+++ b/fluent.runtime/fluent/runtime/bundle.py
@@ -1,0 +1,98 @@
+import babel
+import babel.numbers
+import babel.plural
+
+from fluent.syntax.ast import Message, Term
+
+from .builtins import BUILTINS
+from .prepare import Compiler
+from .resolver import ResolverEnvironment, CurrentEnvironment
+from .utils import native_to_fluent
+
+
+class FluentBundle:
+    """
+    Bundles are single-language stores of translations.  They are
+    aggregate parsed Fluent resources in the Fluent syntax and can
+    format translation units (entities) to strings.
+
+    Always use `FluentBundle.get_message` to retrieve translation units from
+    a bundle. Generate the localized string by using `format_pattern` on
+    `message.value` or `message.attributes['attr']`.
+    Translations can contain references to other entities or
+    external arguments, conditional logic in form of select expressions, traits
+    which describe their grammatical features, and can use Fluent builtins.
+    See the documentation of the Fluent syntax for more information.
+    """
+
+    def __init__(self, locales, functions=None, use_isolating=True):
+        self.locales = locales
+        _functions = BUILTINS.copy()
+        if functions:
+            _functions.update(functions)
+        self._functions = _functions
+        self.use_isolating = use_isolating
+        self._messages = {}
+        self._terms = {}
+        self._compiled = {}
+        self._compiler = Compiler()
+        self._babel_locale = self._get_babel_locale()
+        self._plural_form = babel.plural.to_python(self._babel_locale.plural_form)
+
+    def add_resource(self, resource, allow_overrides=False):
+        # TODO - warn/error about duplicates
+        for item in resource.body:
+            if not isinstance(item, (Message, Term)):
+                continue
+            map_ = self._messages if isinstance(item, Message) else self._terms
+            full_id = item.id.name
+            if full_id not in map_ or allow_overrides:
+                map_[full_id] = item
+
+    def has_message(self, message_id):
+        return message_id in self._messages
+
+    def get_message(self, message_id):
+        return self._lookup(message_id)
+
+    def _lookup(self, entry_id, term=False):
+        if term:
+            compiled_id = '-' + entry_id
+        else:
+            compiled_id = entry_id
+        try:
+            return self._compiled[compiled_id]
+        except LookupError:
+            pass
+        entry = self._terms[entry_id] if term else self._messages[entry_id]
+        self._compiled[compiled_id] = self._compiler(entry)
+        return self._compiled[compiled_id]
+
+    def format_pattern(self, pattern, args=None):
+        if args is not None:
+            fluent_args = {
+                argname: native_to_fluent(argvalue)
+                for argname, argvalue in args.items()
+            }
+        else:
+            fluent_args = {}
+
+        errors = []
+        env = ResolverEnvironment(context=self,
+                                  current=CurrentEnvironment(args=fluent_args),
+                                  errors=errors)
+        try:
+            result = pattern(env)
+        except ValueError as e:
+            errors.append(e)
+            result = '{???}'
+        return [result, errors]
+
+    def _get_babel_locale(self):
+        for lc in self.locales:
+            try:
+                return babel.Locale.parse(lc.replace('-', '_'))
+            except babel.UnknownLocaleError:
+                continue
+        # TODO - log error
+        return babel.Locale.default()

--- a/fluent.runtime/fluent/runtime/bundle.py
+++ b/fluent.runtime/fluent/runtime/bundle.py
@@ -1,7 +1,8 @@
 import babel
 import babel.numbers
 import babel.plural
-from typing import Any, Callable, Dict, List, Literal, TYPE_CHECKING, Tuple, Union, cast
+from typing import Any, Callable, Dict, List, TYPE_CHECKING, Tuple, Union, cast
+from typing_extensions import Literal
 
 from fluent.syntax import ast as FTL
 

--- a/fluent.runtime/fluent/runtime/errors.py
+++ b/fluent.runtime/fluent/runtime/errors.py
@@ -1,7 +1,9 @@
+from typing import cast
+
+
 class FluentFormatError(ValueError):
-    def __eq__(self, other):
-        return ((other.__class__ == self.__class__) and
-                other.args == self.args)
+    def __eq__(self, other: object) -> bool:
+        return ((other.__class__ == self.__class__) and cast(ValueError, other).args == self.args)
 
 
 class FluentReferenceError(FluentFormatError):

--- a/fluent.runtime/fluent/runtime/fallback.py
+++ b/fluent.runtime/fluent/runtime/fallback.py
@@ -107,7 +107,6 @@ class FluentResourceLoader(AbstractResourceLoader):
         location on disk, or a list of strings.
         """
         self.roots = [roots] if isinstance(roots, str) else roots
-        self.Resource = FluentResource
 
     def resources(self, locale: str, resource_ids: List[str]) -> Generator[List['Resource'], None, None]:
         for root in self.roots:

--- a/fluent.runtime/fluent/runtime/prepare.py
+++ b/fluent.runtime/fluent/runtime/prepare.py
@@ -1,38 +1,36 @@
+from typing import Any, Dict, List
 from fluent.syntax import ast as FTL
 from . import resolver
 
 
 class Compiler:
-    def __call__(self, item):
+    def __call__(self, item: Any) -> Any:
         if isinstance(item, FTL.BaseNode):
             return self.compile(item)
         if isinstance(item, (tuple, list)):
             return [self(elem) for elem in item]
         return item
 
-    def compile(self, node):
-        nodename = type(node).__name__
+    def compile(self, node: Any) -> Any:
+        nodename: str = type(node).__name__
         if not hasattr(resolver, nodename):
             return node
-        kwargs = vars(node).copy()
+        kwargs: Dict[str, Any] = vars(node).copy()
         for propname, propvalue in kwargs.items():
             kwargs[propname] = self(propvalue)
         handler = getattr(self, 'compile_' + nodename, self.compile_generic)
         return handler(nodename, **kwargs)
 
-    def compile_generic(self, nodename, **kwargs):
+    def compile_generic(self, nodename: str, **kwargs: Any) -> Any:
         return getattr(resolver, nodename)(**kwargs)
 
-    def compile_Placeable(self, _, expression, **kwargs):
+    def compile_Placeable(self, _: Any, expression: Any, **kwargs: Any) -> Any:
         if isinstance(expression, resolver.Literal):
             return expression
         return resolver.Placeable(expression=expression, **kwargs)
 
-    def compile_Pattern(self, _, elements, **kwargs):
-        if (
-            len(elements) == 1 and
-            isinstance(elements[0], resolver.Placeable)
-        ):
+    def compile_Pattern(self, _: Any, elements: List[Any], **kwargs: Any) -> Any:
+        if len(elements) == 1 and isinstance(elements[0], resolver.Placeable):
             # Don't isolate isolated placeables
             return resolver.NeverIsolatingPlaceable(elements[0].expression)
         if any(

--- a/fluent.runtime/fluent/runtime/resolver.py
+++ b/fluent.runtime/fluent/runtime/resolver.py
@@ -227,6 +227,10 @@ def resolveEntryReference(
         ref_id = reference_to_id(ref)
         env.errors.append(unknown_reference_error_obj(ref_id))
         return FluentNone(f'{{{ref_id}}}')
+    except TypeError:
+        ref_id = reference_to_id(ref)
+        env.errors.append(FluentReferenceError(f"No pattern: {ref_id}"))
+        return FluentNone(ref_id)
 
 
 class MessageReference(FTL.MessageReference, BaseResolver):
@@ -296,6 +300,9 @@ class SelectExpression(FTL.SelectExpression, BaseResolver):
                 break
 
         if found is None:
+            if default is None:
+                env.errors.append(FluentFormatError("No default"))
+                return FluentNone()
             found = default
         return found.value(env)
 

--- a/fluent.runtime/fluent/runtime/resolver.py
+++ b/fluent.runtime/fluent/runtime/resolver.py
@@ -1,11 +1,14 @@
-import contextlib
-
 import attr
+import contextlib
+from typing import Any, Dict, Generator, List, Set, TYPE_CHECKING, Union, cast
 
 from fluent.syntax import ast as FTL
 from .errors import FluentCyclicReferenceError, FluentFormatError, FluentReferenceError
 from .types import FluentType, FluentNone, FluentInt, FluentFloat
 from .utils import reference_to_id, unknown_reference_error_obj
+
+if TYPE_CHECKING:
+    from .bundle import FluentBundle
 
 
 """
@@ -38,22 +41,22 @@ class CurrentEnvironment:
     # For Messages, VariableReference nodes are interpreted as external args,
     # but for Terms they are the values explicitly passed using CallExpression
     # syntax. So we have to be able to change 'args' for this purpose.
-    args = attr.ib()
+    args: Dict[str, Any] = attr.ib(factory=dict)
     # This controls whether we need to report an error if a VariableReference
     # refers to an arg that is not present in the args dict.
-    error_for_missing_arg = attr.ib(default=True)
+    error_for_missing_arg: bool = attr.ib(default=True)
 
 
 @attr.s
 class ResolverEnvironment:
-    context = attr.ib()
-    errors = attr.ib()
-    part_count = attr.ib(default=0, init=False)
-    active_patterns = attr.ib(factory=set, init=False)
-    current = attr.ib(factory=CurrentEnvironment)
+    context: 'FluentBundle' = attr.ib()
+    errors: List[Exception] = attr.ib()
+    part_count: int = attr.ib(default=0, init=False)
+    active_patterns: Set[FTL.Pattern] = attr.ib(factory=set, init=False)
+    current: CurrentEnvironment = attr.ib(factory=CurrentEnvironment)
 
     @contextlib.contextmanager
-    def modified(self, **replacements):
+    def modified(self, **replacements: Any) -> Generator['ResolverEnvironment', None, None]:
         """
         Context manager that modifies the 'current' attribute of the
         environment, restoring the old data at the end.
@@ -65,7 +68,7 @@ class ResolverEnvironment:
         yield self
         self.current = old_current
 
-    def modified_for_term_reference(self, args=None):
+    def modified_for_term_reference(self, args: Union[Dict[str, Any], None] = None) -> Any:
         return self.modified(args=args if args is not None else {},
                              error_for_missing_arg=False)
 
@@ -79,46 +82,59 @@ class BaseResolver:
     classes that don't show up in the evaluation, but need to
     be part of the compiled tree structure.
     """
-    def __call__(self, env):
+
+    def __call__(self, env: ResolverEnvironment) -> Any:
         raise NotImplementedError
 
 
 class Literal(BaseResolver):
-    pass
+    value: str
 
 
-class EntryResolver(BaseResolver):
-    '''Entries (Messages and Terms) have attributes.
-    In the AST they're a list, the resolver wants a dict. The helper method
-    here should be called from the constructor.
-    '''
-    def _fix_attributes(self):
-        self.attributes = {
-            attr.id.name: attr.value
-            for attr in self.attributes
-        }
+class Message(FTL.Entry, BaseResolver):
+    id: 'Identifier'
+    value: Union['Pattern', None]
+    attributes: Dict[str, 'Pattern']
+
+    def __init__(self,
+                 id: 'Identifier',
+                 value: Union['Pattern', None] = None,
+                 attributes: Union[List['Attribute'], None] = None,
+                 comment: Any = None,
+                 **kwargs: Any):
+        super().__init__(**kwargs)
+        self.id = id
+        self.value = value
+        self.attributes = {attr.id.name: attr.value for attr in attributes} if attributes else {}
 
 
-class Message(FTL.Message, EntryResolver):
-    def __init__(self, id, **kwargs):
-        super().__init__(id, **kwargs)
-        self._fix_attributes()
+class Term(FTL.Entry, BaseResolver):
+    id: 'Identifier'
+    value: 'Pattern'
+    attributes: Dict[str, 'Pattern']
 
-
-class Term(FTL.Term, EntryResolver):
-    def __init__(self, id, value, **kwargs):
-        super().__init__(id, value, **kwargs)
-        self._fix_attributes()
+    def __init__(self,
+                 id: 'Identifier',
+                 value: 'Pattern',
+                 attributes: Union[List['Attribute'], None] = None,
+                 comment: Any = None,
+                 **kwargs: Any):
+        super().__init__(**kwargs)
+        self.id = id
+        self.value = value
+        self.attributes = {attr.id.name: attr.value for attr in attributes} if attributes else {}
 
 
 class Pattern(FTL.Pattern, BaseResolver):
     # Prevent messages with too many sub parts, for CPI DOS protection
     MAX_PARTS = 1000
 
-    def __init__(self, *args, **kwargs):
+    elements: List[Union['TextElement', 'Placeable']]  # type: ignore
+
+    def __init__(self, *args: Any, **kwargs: Any):
         super().__init__(*args, **kwargs)
 
-    def __call__(self, env):
+    def __call__(self, env: ResolverEnvironment) -> Union[str, FluentNone]:
         if self in env.active_patterns:
             env.errors.append(FluentCyclicReferenceError("Cyclic reference"))
             return FluentNone()
@@ -137,7 +153,7 @@ class Pattern(FTL.Pattern, BaseResolver):
         return retval
 
 
-def resolve(fluentish, env):
+def resolve(fluentish: Any, env: ResolverEnvironment) -> Any:
     if isinstance(fluentish, FluentType):
         return fluentish.format(env.context._babel_locale)
     if isinstance(fluentish, str):
@@ -150,12 +166,16 @@ def resolve(fluentish, env):
 
 
 class TextElement(FTL.TextElement, Literal):
-    def __call__(self, env):
+    value: str
+
+    def __call__(self, env: ResolverEnvironment) -> str:
         return self.value
 
 
 class Placeable(FTL.Placeable, BaseResolver):
-    def __call__(self, env):
+    expression: Union['InlineExpression', 'Placeable', 'SelectExpression']
+
+    def __call__(self, env: ResolverEnvironment) -> Any:
         inner = resolve(self.expression(env), env)
         if not env.context.use_isolating:
             return inner
@@ -163,49 +183,66 @@ class Placeable(FTL.Placeable, BaseResolver):
 
 
 class NeverIsolatingPlaceable(FTL.Placeable, BaseResolver):
-    def __call__(self, env):
+    expression: Union['InlineExpression', Placeable, 'SelectExpression']
+
+    def __call__(self, env: ResolverEnvironment) -> Any:
         inner = resolve(self.expression(env), env)
         return inner
 
 
 class StringLiteral(FTL.StringLiteral, Literal):
-    def __call__(self, env):
+    value: str
+
+    def __call__(self, env: ResolverEnvironment) -> str:
         return self.parse()['value']
 
 
 class NumberLiteral(FTL.NumberLiteral, BaseResolver):
-    def __init__(self, value, **kwargs):
+    value: Union[FluentFloat, FluentInt]  # type: ignore
+
+    def __init__(self, value: str, **kwargs: Any):
         super().__init__(value, **kwargs)
-        if '.' in self.value:
+        if '.' in cast(str, self.value):
             self.value = FluentFloat(self.value)
         else:
             self.value = FluentInt(self.value)
 
-    def __call__(self, env):
+    def __call__(self, env: ResolverEnvironment) -> Union[FluentFloat, FluentInt]:
         return self.value
 
 
-class EntryReference(BaseResolver):
-    def __call__(self, env):
-        try:
-            entry = env.context._lookup(self.id.name, term=isinstance(self, FTL.TermReference))
-            if self.attribute:
-                pattern = entry.attributes[self.attribute.name]
-            else:
-                pattern = entry.value
-            return pattern(env)
-        except LookupError:
-            ref_id = reference_to_id(self)
-            env.errors.append(unknown_reference_error_obj(ref_id))
-            return FluentNone(f'{{{ref_id}}}')
+def resolveEntryReference(
+        ref: Union['MessageReference', 'TermReference'],
+        env: ResolverEnvironment
+) -> Union[str, FluentNone]:
+    try:
+        entry = env.context._lookup(ref.id.name, term=isinstance(ref, FTL.TermReference))
+        pattern: Pattern
+        if ref.attribute:
+            pattern = entry.attributes[ref.attribute.name]
+        else:
+            pattern = entry.value  # type: ignore
+        return pattern(env)
+    except LookupError:
+        ref_id = reference_to_id(ref)
+        env.errors.append(unknown_reference_error_obj(ref_id))
+        return FluentNone(f'{{{ref_id}}}')
 
 
-class MessageReference(FTL.MessageReference, EntryReference):
-    pass
+class MessageReference(FTL.MessageReference, BaseResolver):
+    id: 'Identifier'
+    attribute: Union['Identifier', None]
+
+    def __call__(self, env: ResolverEnvironment) -> Union[str, FluentNone]:
+        return resolveEntryReference(self, env)
 
 
-class TermReference(FTL.TermReference, EntryReference):
-    def __call__(self, env):
+class TermReference(FTL.TermReference, BaseResolver):
+    id: 'Identifier'
+    attribute: Union['Identifier', None]
+    arguments: Union['CallArguments', None]
+
+    def __call__(self, env: ResolverEnvironment) -> Union[str, FluentNone]:
         if self.arguments:
             if self.arguments.positional:
                 env.errors.append(FluentFormatError("Ignored positional arguments passed to term '{}'"
@@ -214,11 +251,13 @@ class TermReference(FTL.TermReference, EntryReference):
         else:
             kwargs = None
         with env.modified_for_term_reference(args=kwargs):
-            return super().__call__(env)
+            return resolveEntryReference(self, env)
 
 
 class VariableReference(FTL.VariableReference, BaseResolver):
-    def __call__(self, env):
+    id: 'Identifier'
+
+    def __call__(self, env: ResolverEnvironment) -> Any:
         name = self.id.name
         try:
             arg_val = env.current.args[name]
@@ -236,17 +275,18 @@ class VariableReference(FTL.VariableReference, BaseResolver):
 
 
 class Attribute(FTL.Attribute, BaseResolver):
-    pass
+    id: 'Identifier'
+    value: Pattern
 
 
 class SelectExpression(FTL.SelectExpression, BaseResolver):
-    def __call__(self, env):
-        key = self.selector(env)
-        return self.select_from_select_expression(env, key=key)
+    selector: 'InlineExpression'
+    variants: List['Variant']  # type: ignore
 
-    def select_from_select_expression(self, env, key):
-        default = None
-        found = None
+    def __call__(self, env: ResolverEnvironment) -> Union[str, FluentNone]:
+        key = self.selector(env)
+        default: Union['Variant', None] = None
+        found: Union['Variant', None] = None
         for variant in self.variants:
             if variant.default:
                 default = variant
@@ -260,11 +300,11 @@ class SelectExpression(FTL.SelectExpression, BaseResolver):
         return found.value(env)
 
 
-def is_number(val):
+def is_number(val: Any) -> bool:
     return isinstance(val, (int, float))
 
 
-def match(val1, val2, env):
+def match(val1: Any, val2: Any, env: ResolverEnvironment) -> bool:
     if val1 is None or isinstance(val1, FluentNone):
         return False
     if val2 is None or isinstance(val2, FluentNone):
@@ -272,28 +312,36 @@ def match(val1, val2, env):
     if is_number(val1):
         if not is_number(val2):
             # Could be plural rule match
-            return env.context._plural_form(val1) == val2
+            return cast(bool, env.context._plural_form(val1) == val2)
     elif is_number(val2):
         return match(val2, val1, env)
 
-    return val1 == val2
+    return cast(bool, val1 == val2)
 
 
 class Variant(FTL.Variant, BaseResolver):
-    pass
+    key: Union['Identifier', NumberLiteral]
+    value: Pattern
+    default: bool
 
 
 class Identifier(FTL.Identifier, BaseResolver):
-    def __call__(self, env):
+    name: str
+
+    def __call__(self, env: ResolverEnvironment) -> str:
         return self.name
 
 
 class CallArguments(FTL.CallArguments, BaseResolver):
-    pass
+    positional: List[Union['InlineExpression', Placeable]]  # type: ignore
+    named: List['NamedArgument']  # type: ignore
 
 
 class FunctionReference(FTL.FunctionReference, BaseResolver):
-    def __call__(self, env):
+    id: Identifier
+    arguments: CallArguments
+
+    def __call__(self, env: ResolverEnvironment) -> Any:
         args = [arg(env) for arg in self.arguments.positional]
         kwargs = {kwarg.name.name: kwarg.value(env) for kwarg in self.arguments.named}
         function_name = self.id.name
@@ -312,4 +360,9 @@ class FunctionReference(FTL.FunctionReference, BaseResolver):
 
 
 class NamedArgument(FTL.NamedArgument, BaseResolver):
-    pass
+    name: Identifier
+    value: Union[NumberLiteral, StringLiteral]
+
+
+InlineExpression = Union[NumberLiteral, StringLiteral, MessageReference,
+                         TermReference, VariableReference, FunctionReference]

--- a/fluent.runtime/fluent/runtime/types.py
+++ b/fluent.runtime/fluent/runtime/types.py
@@ -7,7 +7,8 @@ import pytz
 from babel import Locale
 from babel.dates import format_date, format_time, get_datetime_format, get_timezone
 from babel.numbers import NumberPattern, parse_pattern
-from typing import Any, Dict, Literal, Type, TypeVar, Union, cast
+from typing import Any, Dict, Type, TypeVar, Union, cast
+from typing_extensions import Literal
 
 FORMAT_STYLE_DECIMAL = "decimal"
 FORMAT_STYLE_CURRENCY = "currency"

--- a/fluent.runtime/fluent/runtime/types.py
+++ b/fluent.runtime/fluent/runtime/types.py
@@ -118,6 +118,8 @@ class FluentNumber(FluentType):
             base_pattern = locale.currency_formats['standard']
             pattern = self._apply_options(base_pattern)
             return pattern.apply(selfnum, locale, currency=self.options.currency)
+        # never happens
+        return '???'
 
     def _apply_options(self, pattern: NumberPattern) -> NumberPattern:
         # We are essentially trying to copy the
@@ -339,8 +341,6 @@ def _ensure_datetime_tzinfo(dt: datetime, tzinfo: Union[str, None] = None) -> da
         dt = dt.replace(tzinfo=pytz.UTC)
     if tzinfo is not None:
         dt = dt.astimezone(get_timezone(tzinfo))
-        if hasattr(tzinfo, 'normalize'):  # pytz
-            dt = tzinfo.normalize(datetime)
     return dt
 
 

--- a/fluent.runtime/fluent/runtime/utils.py
+++ b/fluent.runtime/fluent/runtime/utils.py
@@ -1,7 +1,8 @@
 from datetime import date, datetime
 from decimal import Decimal
+from typing import Any, Union
 
-from fluent.syntax.ast import TermReference
+from fluent.syntax.ast import MessageReference, TermReference
 
 from .types import FluentInt, FluentFloat, FluentDecimal, FluentDate, FluentDateTime
 from .errors import FluentReferenceError
@@ -10,7 +11,7 @@ TERM_SIGIL = '-'
 ATTRIBUTE_SEPARATOR = '.'
 
 
-def native_to_fluent(val):
+def native_to_fluent(val: Any) -> Any:
     """
     Convert a python type to a Fluent Type.
     """
@@ -28,7 +29,7 @@ def native_to_fluent(val):
     return val
 
 
-def reference_to_id(ref):
+def reference_to_id(ref: Union[MessageReference, TermReference]) -> str:
     """
     Returns a string reference for a MessageReference or TermReference
     AST node.
@@ -39,6 +40,7 @@ def reference_to_id(ref):
        -term
        -term.attr
     """
+    start: str
     if isinstance(ref, TermReference):
         start = TERM_SIGIL + ref.id.name
     else:
@@ -49,7 +51,7 @@ def reference_to_id(ref):
     return start
 
 
-def unknown_reference_error_obj(ref_id):
+def unknown_reference_error_obj(ref_id: str) -> FluentReferenceError:
     if ATTRIBUTE_SEPARATOR in ref_id:
         return FluentReferenceError(f"Unknown attribute: {ref_id}")
     if ref_id.startswith(TERM_SIGIL):

--- a/fluent.runtime/setup.cfg
+++ b/fluent.runtime/setup.cfg
@@ -12,3 +12,6 @@ max-line-length=120
 line_length=120
 skip_glob=.tox
 not_skip=__init__.py
+
+[mypy]
+strict = True

--- a/fluent.runtime/setup.py
+++ b/fluent.runtime/setup.py
@@ -33,6 +33,7 @@ setup(name='fluent.runtime',
           'attrs',
           'babel',
           'pytz',
+          'typing-extensions>=3.7,<5'
       ],
       test_suite='tests',
       )

--- a/fluent.runtime/setup.py
+++ b/fluent.runtime/setup.py
@@ -1,8 +1,8 @@
-from setuptools import setup, find_namespace_packages
-import os
+from os import path
+from setuptools import setup
 
-this_directory = os.path.abspath(os.path.dirname(__file__))
-with open(os.path.join(this_directory, 'README.rst'), 'rb') as f:
+this_directory = path.abspath(path.dirname(__file__))
+with open(path.join(this_directory, 'README.rst'), 'rb') as f:
     long_description = f.read().decode('utf-8')
 
 
@@ -25,14 +25,14 @@ setup(name='fluent.runtime',
           'Programming Language :: Python :: 3.9',
           'Programming Language :: Python :: 3 :: Only',
       ],
-      packages=find_namespace_packages(include=['fluent.*']),
+      packages=['fluent.runtime'],
+      package_data={'fluent.runtime': ['py.typed']},
       # These should also be duplicated in tox.ini and /.github/workflows/fluent.runtime.yml
       install_requires=[
           'fluent.syntax>=0.17,<0.20',
           'attrs',
           'babel',
           'pytz',
-          'six',
       ],
       test_suite='tests',
       )

--- a/fluent.runtime/tests/test_types.py
+++ b/fluent.runtime/tests/test_types.py
@@ -45,7 +45,7 @@ class TestFluentNumber(unittest.TestCase):
             fluent_number,
             1,
             not_a_real_option=True,
-            )
+        )
 
     def test_style_validation(self):
         self.assertRaises(ValueError,
@@ -213,14 +213,14 @@ class TestFluentDate(unittest.TestCase):
         fd = fluent_date(self.a_datetime, timeStyle='short')
         en_US = Locale.parse('en_US')
         en_GB = Locale.parse('en_GB')
-        self.assertEqual(fd.format(en_US), '2:15 PM')
+        self.assertRegex(fd.format(en_US), '^2:15\\sPM$')
         self.assertEqual(fd.format(en_GB), '14:15')
 
     def test_dateStyle_and_timeStyle_datetime(self):
         fd = fluent_date(self.a_datetime, timeStyle='short', dateStyle='short')
         en_US = Locale.parse('en_US')
         en_GB = Locale.parse('en_GB')
-        self.assertEqual(fd.format(en_US), '2/1/18, 2:15 PM')
+        self.assertRegex(fd.format(en_US), '^2/1/18, 2:15\\sPM$')
         self.assertEqual(fd.format(en_GB), '01/02/2018, 14:15')
 
     def test_validate_dateStyle(self):
@@ -246,7 +246,7 @@ class TestFluentDate(unittest.TestCase):
         fd1 = fluent_date(dt1, dateStyle='short', timeStyle='short')
         self.assertEqual(fd1.format(en_GB), '02/07/2018, 00:30')
         fd1b = fluent_date(dt1, dateStyle='full', timeStyle='full')
-        self.assertEqual(fd1b.format(en_GB), 'Monday, 2 July 2018 at 00:30:00 British Summer Time')
+        self.assertRegex(fd1b.format(en_GB), '^Monday, 2 July 2018(,| at) 00:30:00 British Summer Time$')
         fd1c = fluent_date(dt1, dateStyle='short')
         self.assertEqual(fd1c.format(en_GB), '02/07/2018')
         fd1d = fluent_date(dt1, timeStyle='short')
@@ -259,7 +259,7 @@ class TestFluentDate(unittest.TestCase):
         self.assertEqual(fd2.format(en_GB), '02/07/2018, 00:30')
         fd2b = fluent_date(dt2, dateStyle='full', timeStyle='full',
                            timeZone='Europe/London')
-        self.assertEqual(fd2b.format(en_GB), 'Monday, 2 July 2018 at 00:30:00 British Summer Time')
+        self.assertRegex(fd2b.format(en_GB), '^Monday, 2 July 2018(,| at) 00:30:00 British Summer Time$')
         fd2c = fluent_date(dt2, dateStyle='short',
                            timeZone='Europe/London')
         self.assertEqual(fd2c.format(en_GB), '02/07/2018')
@@ -290,7 +290,7 @@ class TestFluentDate(unittest.TestCase):
             fluent_date,
             self.a_date,
             not_a_real_option=True,
-            )
+        )
 
     def test_dont_wrap_unnecessarily(self):
         f1 = fluent_date(self.a_date)

--- a/fluent.runtime/tox.ini
+++ b/fluent.runtime/tox.ini
@@ -12,7 +12,6 @@ deps =
      attrs==19.1.0
      babel==2.7.0
      pytz==2019.2
-     six==1.12.0
      syntax: .
 commands = ./runtests.py
 
@@ -20,4 +19,3 @@ commands = ./runtests.py
 basepython = python3
 deps =
      .
-     six

--- a/fluent.runtime/tox.ini
+++ b/fluent.runtime/tox.ini
@@ -12,6 +12,7 @@ deps =
      attrs==19.1.0
      babel==2.7.0
      pytz==2019.2
+     typing-extensions==3.7
      syntax: .
 commands = ./runtests.py
 

--- a/fluent.syntax/fluent/syntax/__init__.py
+++ b/fluent.syntax/fluent/syntax/__init__.py
@@ -1,17 +1,33 @@
 from typing import Any
-from .ast import Resource
+
+from . import ast
+from .errors import ParseError
 from .parser import FluentParser
 from .serializer import FluentSerializer
+from .stream import FluentParserStream
+from .visitor import Transformer, Visitor
+
+__all__ = [
+    'FluentParser',
+    'FluentParserStream',
+    'FluentSerializer',
+    'ParseError',
+    'Transformer',
+    'Visitor',
+    'ast',
+    'parse',
+    'serialize'
+]
 
 
-def parse(source: str, **kwargs: Any) -> Resource:
+def parse(source: str, **kwargs: Any) -> ast.Resource:
     """Create an ast.Resource from a Fluent Syntax source.
     """
     parser = FluentParser(**kwargs)
     return parser.parse(source)
 
 
-def serialize(resource: Resource, **kwargs: Any) -> str:
+def serialize(resource: ast.Resource, **kwargs: Any) -> str:
     """Serialize an ast.Resource to a unicode string.
     """
     serializer = FluentSerializer(**kwargs)

--- a/fluent.syntax/fluent/syntax/__init__.py
+++ b/fluent.syntax/fluent/syntax/__init__.py
@@ -1,15 +1,17 @@
+from typing import Any
+from .ast import Resource
 from .parser import FluentParser
 from .serializer import FluentSerializer
 
 
-def parse(source, **kwargs):
+def parse(source: str, **kwargs: Any) -> Resource:
     """Create an ast.Resource from a Fluent Syntax source.
     """
     parser = FluentParser(**kwargs)
     return parser.parse(source)
 
 
-def serialize(resource, **kwargs):
+def serialize(resource: Resource, **kwargs: Any) -> str:
     """Serialize an ast.Resource to a unicode string.
     """
     serializer = FluentSerializer(**kwargs)

--- a/fluent.syntax/fluent/syntax/ast.py
+++ b/fluent.syntax/fluent/syntax/ast.py
@@ -1,9 +1,13 @@
 import re
 import sys
 import json
+from typing import Any, Callable, Dict, List, TypeVar, Union, cast
+
+Node = TypeVar('Node', bound='BaseNode')
+ToJsonFn = Callable[[Dict[str, Any]], Any]
 
 
-def to_json(value, fn=None):
+def to_json(value: Any, fn: Union[ToJsonFn, None] = None) -> Any:
     if isinstance(value, BaseNode):
         return value.to_json(fn)
     if isinstance(value, list):
@@ -14,7 +18,7 @@ def to_json(value, fn=None):
         return value
 
 
-def from_json(value):
+def from_json(value: Any) -> Any:
     if isinstance(value, dict):
         cls = getattr(sys.modules[__name__], value['type'])
         args = {
@@ -29,7 +33,7 @@ def from_json(value):
         return value
 
 
-def scalars_equal(node1, node2, ignored_fields):
+def scalars_equal(node1: Any, node2: Any, ignored_fields: List[str]) -> bool:
     """Compare two nodes which are not lists."""
 
     if type(node1) != type(node2):
@@ -38,7 +42,7 @@ def scalars_equal(node1, node2, ignored_fields):
     if isinstance(node1, BaseNode):
         return node1.equals(node2, ignored_fields)
 
-    return node1 == node2
+    return cast(bool, node1 == node2)
 
 
 class BaseNode:
@@ -48,9 +52,9 @@ class BaseNode:
     Annotation.  Implements __str__, to_json and traverse.
     """
 
-    def clone(self):
+    def clone(self: Node) -> Node:
         """Create a deep clone of the current node."""
-        def visit(value):
+        def visit(value: Any) -> Any:
             """Clone node and its descendants."""
             if isinstance(value, BaseNode):
                 return value.clone()
@@ -65,7 +69,7 @@ class BaseNode:
             **{name: visit(value) for name, value in vars(self).items()}
         )
 
-    def equals(self, other, ignored_fields=['span']):
+    def equals(self, other: 'BaseNode', ignored_fields: List[str] = ['span']) -> bool:
         """Compare two nodes.
 
         Nodes are deeply compared on a field by field basis. If possible, False
@@ -104,7 +108,7 @@ class BaseNode:
 
         return True
 
-    def to_json(self, fn=None):
+    def to_json(self, fn: Union[ToJsonFn, None] = None) -> Any:
         obj = {
             name: to_json(value, fn)
             for name, value in vars(self).items()
@@ -114,23 +118,23 @@ class BaseNode:
         )
         return fn(obj) if fn else obj
 
-    def __str__(self):
+    def __str__(self) -> str:
         return json.dumps(self.to_json())
 
 
 class SyntaxNode(BaseNode):
     """Base class for AST nodes which can have Spans."""
 
-    def __init__(self, span=None, **kwargs):
+    def __init__(self, span: Union['Span', None] = None, **kwargs: Any):
         super().__init__(**kwargs)
         self.span = span
 
-    def add_span(self, start, end):
+    def add_span(self, start: int, end: int) -> None:
         self.span = Span(start, end)
 
 
 class Resource(SyntaxNode):
-    def __init__(self, body=None, **kwargs):
+    def __init__(self, body: Union[List['EntryType'], None] = None, **kwargs: Any):
         super().__init__(**kwargs)
         self.body = body or []
 
@@ -140,8 +144,12 @@ class Entry(SyntaxNode):
 
 
 class Message(Entry):
-    def __init__(self, id, value=None, attributes=None,
-                 comment=None, **kwargs):
+    def __init__(self,
+                 id: 'Identifier',
+                 value: Union['Pattern', None] = None,
+                 attributes: Union[List['Attribute'], None] = None,
+                 comment: Union['Comment', None] = None,
+                 **kwargs: Any):
         super().__init__(**kwargs)
         self.id = id
         self.value = value
@@ -150,8 +158,8 @@ class Message(Entry):
 
 
 class Term(Entry):
-    def __init__(self, id, value, attributes=None,
-                 comment=None, **kwargs):
+    def __init__(self, id: 'Identifier', value: 'Pattern', attributes: Union[List['Attribute'], None] = None,
+                 comment: Union['Comment', None] = None, **kwargs: Any):
         super().__init__(**kwargs)
         self.id = id
         self.value = value
@@ -160,7 +168,7 @@ class Term(Entry):
 
 
 class Pattern(SyntaxNode):
-    def __init__(self, elements, **kwargs):
+    def __init__(self, elements: List[Union['TextElement', 'Placeable']], **kwargs: Any):
         super().__init__(**kwargs)
         self.elements = elements
 
@@ -170,13 +178,15 @@ class PatternElement(SyntaxNode):
 
 
 class TextElement(PatternElement):
-    def __init__(self, value, **kwargs):
+    def __init__(self, value: str, **kwargs: Any):
         super().__init__(**kwargs)
         self.value = value
 
 
 class Placeable(PatternElement):
-    def __init__(self, expression, **kwargs):
+    def __init__(self,
+                 expression: Union['InlineExpression', 'Placeable', 'SelectExpression'],
+                 **kwargs: Any):
         super().__init__(**kwargs)
         self.expression = expression
 
@@ -187,20 +197,21 @@ class Expression(SyntaxNode):
 
 class Literal(Expression):
     """An abstract base class for literals."""
-    def __init__(self, value, **kwargs):
+
+    def __init__(self, value: str, **kwargs: Any):
         super().__init__(**kwargs)
         self.value = value
 
-    def parse(self):
+    def parse(self) -> Dict[str, Any]:
         return {'value': self.value}
 
 
 class StringLiteral(Literal):
-    def parse(self):
-        def from_escape_sequence(matchobj):
+    def parse(self) -> Dict[str, str]:
+        def from_escape_sequence(matchobj: Any) -> str:
             c, codepoint4, codepoint6 = matchobj.groups()
             if c:
-                return c
+                return cast(str, c)
             codepoint = int(codepoint4 or codepoint6, 16)
             if codepoint <= 0xD7FF or 0xE000 <= codepoint:
                 return chr(codepoint)
@@ -218,7 +229,7 @@ class StringLiteral(Literal):
 
 
 class NumberLiteral(Literal):
-    def parse(self):
+    def parse(self) -> Dict[str, Union[float, int]]:
         value = float(self.value)
         decimal_position = self.value.find('.')
         precision = 0
@@ -231,14 +242,18 @@ class NumberLiteral(Literal):
 
 
 class MessageReference(Expression):
-    def __init__(self, id, attribute=None, **kwargs):
+    def __init__(self, id: 'Identifier', attribute: Union['Identifier', None] = None, **kwargs: Any):
         super().__init__(**kwargs)
         self.id = id
         self.attribute = attribute
 
 
 class TermReference(Expression):
-    def __init__(self, id, attribute=None, arguments=None, **kwargs):
+    def __init__(self,
+                 id: 'Identifier',
+                 attribute: Union['Identifier', None] = None,
+                 arguments: Union['CallArguments', None] = None,
+                 **kwargs: Any):
         super().__init__(**kwargs)
         self.id = id
         self.attribute = attribute
@@ -246,41 +261,44 @@ class TermReference(Expression):
 
 
 class VariableReference(Expression):
-    def __init__(self, id, **kwargs):
+    def __init__(self, id: 'Identifier', **kwargs: Any):
         super().__init__(**kwargs)
         self.id = id
 
 
 class FunctionReference(Expression):
-    def __init__(self, id, arguments, **kwargs):
+    def __init__(self, id: 'Identifier', arguments: 'CallArguments', **kwargs: Any):
         super().__init__(**kwargs)
         self.id = id
         self.arguments = arguments
 
 
 class SelectExpression(Expression):
-    def __init__(self, selector, variants, **kwargs):
+    def __init__(self, selector: 'InlineExpression', variants: List['Variant'], **kwargs: Any):
         super().__init__(**kwargs)
         self.selector = selector
         self.variants = variants
 
 
 class CallArguments(SyntaxNode):
-    def __init__(self, positional=None, named=None, **kwargs):
+    def __init__(self,
+                 positional: Union[List[Union['InlineExpression', Placeable]], None] = None,
+                 named: Union[List['NamedArgument'], None] = None,
+                 **kwargs: Any):
         super().__init__(**kwargs)
         self.positional = [] if positional is None else positional
         self.named = [] if named is None else named
 
 
 class Attribute(SyntaxNode):
-    def __init__(self, id, value, **kwargs):
+    def __init__(self, id: 'Identifier', value: Pattern, **kwargs: Any):
         super().__init__(**kwargs)
         self.id = id
         self.value = value
 
 
 class Variant(SyntaxNode):
-    def __init__(self, key, value, default=False, **kwargs):
+    def __init__(self, key: Union['Identifier', NumberLiteral], value: Pattern, default: bool = False, **kwargs: Any):
         super().__init__(**kwargs)
         self.key = key
         self.value = value
@@ -288,59 +306,71 @@ class Variant(SyntaxNode):
 
 
 class NamedArgument(SyntaxNode):
-    def __init__(self, name, value, **kwargs):
+    def __init__(self, name: 'Identifier', value: Union[NumberLiteral, StringLiteral], **kwargs: Any):
         super().__init__(**kwargs)
         self.name = name
         self.value = value
 
 
 class Identifier(SyntaxNode):
-    def __init__(self, name, **kwargs):
+    def __init__(self, name: str, **kwargs: Any):
         super().__init__(**kwargs)
         self.name = name
 
 
 class BaseComment(Entry):
-    def __init__(self, content=None, **kwargs):
+    def __init__(self, content: Union[str, None] = None, **kwargs: Any):
         super().__init__(**kwargs)
         self.content = content
 
 
 class Comment(BaseComment):
-    def __init__(self, content=None, **kwargs):
+    def __init__(self, content: Union[str, None] = None, **kwargs: Any):
         super().__init__(content, **kwargs)
 
 
 class GroupComment(BaseComment):
-    def __init__(self, content=None, **kwargs):
+    def __init__(self, content: Union[str, None] = None, **kwargs: Any):
         super().__init__(content, **kwargs)
 
 
 class ResourceComment(BaseComment):
-    def __init__(self, content=None, **kwargs):
+    def __init__(self, content: Union[str, None] = None, **kwargs: Any):
         super().__init__(content, **kwargs)
 
 
 class Junk(SyntaxNode):
-    def __init__(self, content=None, annotations=None, **kwargs):
+    def __init__(self,
+                 content: Union[str, None] = None,
+                 annotations: Union[List['Annotation'], None] = None,
+                 **kwargs: Any):
         super().__init__(**kwargs)
         self.content = content
         self.annotations = annotations or []
 
-    def add_annotation(self, annot):
+    def add_annotation(self, annot: 'Annotation') -> None:
         self.annotations.append(annot)
 
 
 class Span(BaseNode):
-    def __init__(self, start, end, **kwargs):
+    def __init__(self, start: int, end: int, **kwargs: Any):
         super().__init__(**kwargs)
         self.start = start
         self.end = end
 
 
 class Annotation(SyntaxNode):
-    def __init__(self, code, arguments=None, message=None, **kwargs):
+    def __init__(self,
+                 code: str,
+                 arguments: Union[List[Any], None] = None,
+                 message: Union[str, None] = None,
+                 **kwargs: Any):
         super().__init__(**kwargs)
         self.code = code
         self.arguments = arguments or []
         self.message = message
+
+
+EntryType = Union[Message, Term, Comment, GroupComment, ResourceComment, Junk]
+InlineExpression = Union[NumberLiteral, StringLiteral, MessageReference,
+                         TermReference, VariableReference, FunctionReference]

--- a/fluent.syntax/fluent/syntax/errors.py
+++ b/fluent.syntax/fluent/syntax/errors.py
@@ -1,11 +1,14 @@
+from typing import Tuple, Union
+
+
 class ParseError(Exception):
-    def __init__(self, code, *args):
+    def __init__(self, code: str, *args: Union[str, None]):
         self.code = code
         self.args = args
         self.message = get_error_message(code, args)
 
 
-def get_error_message(code, args):
+def get_error_message(code: str, args: Tuple[Union[str, None], ...]) -> str:
     if code == 'E00001':
         return 'Generic error'
     if code == 'E0002':

--- a/fluent.syntax/fluent/syntax/parser.py
+++ b/fluent.syntax/fluent/syntax/parser.py
@@ -123,7 +123,7 @@ class FluentParser:
             junk = ast.Junk(slice)
             if self.with_spans:
                 junk.add_span(entry_start_pos, next_entry_start)
-            annot = ast.Annotation(err.code, err.args, err.message)
+            annot = ast.Annotation(err.code, list(err.args) if err.args else None, err.message)
             annot.add_span(error_index, error_index)
             junk.add_annotation(annot)
             return junk
@@ -240,6 +240,9 @@ class FluentParser:
     @with_span
     def get_identifier(self, ps: FluentParserStream) -> ast.Identifier:
         name = ps.take_id_start()
+        if name is None:
+            raise ParseError('E0004', 'a-zA-Z')
+
         ch = ps.take_id_char()
         while ch:
             name += ch

--- a/fluent.syntax/fluent/syntax/parser.py
+++ b/fluent.syntax/fluent/syntax/parser.py
@@ -1,11 +1,14 @@
 import re
+from typing import Any, Callable, List, Set, TypeVar, Union, cast
 from . import ast
-from .stream import EOF, EOL, FluentParserStream
+from .stream import EOL, FluentParserStream
 from .errors import ParseError
 
+R = TypeVar("R", bound=ast.SyntaxNode)
 
-def with_span(fn):
-    def decorated(self, ps, *args, **kwargs):
+
+def with_span(fn: Callable[..., R]) -> Callable[..., R]:
+    def decorated(self: 'FluentParser', ps: FluentParserStream, *args: Any, **kwargs: Any) -> Any:
         if not self.with_spans:
             return fn(self, ps, *args, **kwargs)
 
@@ -30,16 +33,17 @@ class FluentParser:
     ``with_spans`` enables source information in the form of
     :class:`.ast.Span` objects for each :class:`.ast.SyntaxNode`.
     """
-    def __init__(self, with_spans=True):
+
+    def __init__(self, with_spans: bool = True):
         self.with_spans = with_spans
 
-    def parse(self, source):
+    def parse(self, source: str) -> ast.Resource:
         """Create a :class:`.ast.Resource` from a Fluent source.
         """
         ps = FluentParserStream(source)
         ps.skip_blank_block()
 
-        entries = []
+        entries: List[ast.EntryType] = []
         last_comment = None
 
         while ps.current_char:
@@ -62,7 +66,7 @@ class FluentParser:
                 if isinstance(entry, (ast.Message, ast.Term)):
                     entry.comment = last_comment
                     if self.with_spans:
-                        entry.span.start = entry.comment.span.start
+                        cast(ast.Span, entry.span).start = cast(ast.Span, entry.comment.span).start
                 else:
                     entries.append(last_comment)
                 # In either case, the stashed comment has been dealt with;
@@ -78,7 +82,7 @@ class FluentParser:
 
         return res
 
-    def parse_entry(self, source):
+    def parse_entry(self, source: str) -> ast.EntryType:
         """Parse the first :class:`.ast.Entry` in source.
 
         Skip all encountered comments and start parsing at the first :class:`.ast.Message`
@@ -99,7 +103,7 @@ class FluentParser:
 
         return self.get_entry_or_junk(ps)
 
-    def get_entry_or_junk(self, ps):
+    def get_entry_or_junk(self, ps: FluentParserStream) -> ast.EntryType:
         entry_start_pos = ps.index
 
         try:
@@ -124,7 +128,7 @@ class FluentParser:
             junk.add_annotation(annot)
             return junk
 
-    def get_entry(self, ps):
+    def get_entry(self, ps: FluentParserStream) -> ast.EntryType:
         if ps.current_char == '#':
             return self.get_comment(ps)
 
@@ -137,7 +141,7 @@ class FluentParser:
         raise ParseError('E0002')
 
     @with_span
-    def get_comment(self, ps):
+    def get_comment(self, ps: FluentParserStream) -> Union[ast.Comment, ast.GroupComment, ast.ResourceComment]:
         # 0 - comment
         # 1 - group comment
         # 2 - resource comment
@@ -162,7 +166,7 @@ class FluentParser:
                     ch = ps.take_char(lambda x: x != EOL)
 
             if ps.is_next_line_comment(level=level):
-                content += ps.current_char
+                content += cast(str, ps.current_char)
                 ps.next()
             else:
                 break
@@ -174,8 +178,11 @@ class FluentParser:
         elif level == 2:
             return ast.ResourceComment(content)
 
+        # never happens if ps.current_char == '#' when called
+        return cast(ast.Comment, None)
+
     @with_span
-    def get_message(self, ps):
+    def get_message(self, ps: FluentParserStream) -> ast.Message:
         id = self.get_identifier(ps)
         ps.skip_blank_inline()
         ps.expect_char('=')
@@ -189,7 +196,7 @@ class FluentParser:
         return ast.Message(id, value, attrs)
 
     @with_span
-    def get_term(self, ps):
+    def get_term(self, ps: FluentParserStream) -> ast.Term:
         ps.expect_char('-')
         id = self.get_identifier(ps)
 
@@ -204,7 +211,7 @@ class FluentParser:
         return ast.Term(id, value, attrs)
 
     @with_span
-    def get_attribute(self, ps):
+    def get_attribute(self, ps: FluentParserStream) -> ast.Attribute:
         ps.expect_char('.')
 
         key = self.get_identifier(ps)
@@ -218,8 +225,8 @@ class FluentParser:
 
         return ast.Attribute(key, value)
 
-    def get_attributes(self, ps):
-        attrs = []
+    def get_attributes(self, ps: FluentParserStream) -> List[ast.Attribute]:
+        attrs: List[ast.Attribute] = []
         ps.peek_blank()
 
         while ps.is_attribute_start():
@@ -231,7 +238,7 @@ class FluentParser:
         return attrs
 
     @with_span
-    def get_identifier(self, ps):
+    def get_identifier(self, ps: FluentParserStream) -> ast.Identifier:
         name = ps.take_id_start()
         ch = ps.take_id_char()
         while ch:
@@ -240,10 +247,10 @@ class FluentParser:
 
         return ast.Identifier(name)
 
-    def get_variant_key(self, ps):
+    def get_variant_key(self, ps: FluentParserStream) -> Union[ast.Identifier, ast.NumberLiteral]:
         ch = ps.current_char
 
-        if ch is EOF:
+        if ch is None:
             raise ParseError('E0013')
 
         cc = ord(ch)
@@ -253,7 +260,7 @@ class FluentParser:
         return self.get_identifier(ps)
 
     @with_span
-    def get_variant(self, ps, has_default):
+    def get_variant(self, ps: FluentParserStream, has_default: bool) -> ast.Variant:
         default_index = False
 
         if ps.current_char == '*':
@@ -276,8 +283,8 @@ class FluentParser:
 
         return ast.Variant(key, value, default_index)
 
-    def get_variants(self, ps):
-        variants = []
+    def get_variants(self, ps: FluentParserStream) -> List[ast.Variant]:
+        variants: List[ast.Variant] = []
         has_default = False
 
         ps.skip_blank()
@@ -299,7 +306,7 @@ class FluentParser:
 
         return variants
 
-    def get_digits(self, ps):
+    def get_digits(self, ps: FluentParserStream) -> str:
         num = ''
 
         ch = ps.take_digit()
@@ -313,7 +320,7 @@ class FluentParser:
         return num
 
     @with_span
-    def get_number(self, ps):
+    def get_number(self, ps: FluentParserStream) -> ast.NumberLiteral:
         num = ''
 
         if ps.current_char == '-':
@@ -329,7 +336,7 @@ class FluentParser:
 
         return ast.NumberLiteral(num)
 
-    def maybe_get_pattern(self, ps):
+    def maybe_get_pattern(self, ps: FluentParserStream) -> Union[ast.Pattern, None]:
         '''Parse an inline or a block Pattern, or None
 
         maybe_get_pattern distinguishes between patterns which start on the
@@ -352,8 +359,8 @@ class FluentParser:
         return None
 
     @with_span
-    def get_pattern(self, ps, is_block):
-        elements = []
+    def get_pattern(self, ps: FluentParserStream, is_block: bool) -> ast.Pattern:
+        elements: List[Any] = []
         if is_block:
             # A block pattern is a pattern which starts on a new line. Measure
             # the indent of this first line for the dedentation logic.
@@ -362,7 +369,8 @@ class FluentParser:
             elements.append(self.Indent(first_indent, blank_start, ps.index))
             common_indent_length = len(first_indent)
         else:
-            common_indent_length = float('infinity')
+            # Should get fixed by the subsequent min() operation
+            common_indent_length = cast(int, float('infinity'))
 
         while ps.current_char:
             if ps.current_char == EOL:
@@ -383,6 +391,7 @@ class FluentParser:
             if ps.current_char == '}':
                 raise ParseError('E0027')
 
+            element: Union[ast.TextElement, ast.Placeable]
             if ps.current_char == '{':
                 element = self.get_placeable(ps)
             else:
@@ -394,17 +403,20 @@ class FluentParser:
         return ast.Pattern(dedented)
 
     class Indent(ast.SyntaxNode):
-        def __init__(self, value, start, end):
+        def __init__(self, value: str, start: int, end: int):
             super(FluentParser.Indent, self).__init__()
             self.value = value
             self.add_span(start, end)
 
-    def dedent(self, elements, common_indent):
+    def dedent(self,
+               elements: List[Union[ast.TextElement, ast.Placeable, Indent]],
+               common_indent: int
+               ) -> List[Union[ast.TextElement, ast.Placeable]]:
         '''Dedent a list of elements by removing the maximum common indent from
         the beginning of text lines. The common indent is calculated in
         get_pattern.
         '''
-        trimmed = []
+        trimmed: List[Union[ast.TextElement, ast.Placeable]] = []
 
         for element in elements:
             if isinstance(element, ast.Placeable):
@@ -422,7 +434,7 @@ class FluentParser:
                 # Join adjacent TextElements by replacing them with their sum.
                 sum = ast.TextElement(prev.value + element.value)
                 if self.with_spans:
-                    sum.add_span(prev.span.start, element.span.end)
+                    sum.add_span(cast(ast.Span, prev.span).start, cast(ast.Span, element.span).end)
                 trimmed[-1] = sum
                 continue
 
@@ -431,7 +443,7 @@ class FluentParser:
                 # TextElements, convert it into a new TextElement.
                 text_element = ast.TextElement(element.value)
                 if self.with_spans:
-                    text_element.add_span(element.span.start, element.span.end)
+                    text_element.add_span(cast(ast.Span, element.span).start, cast(ast.Span, element.span).end)
                 element = text_element
 
             trimmed.append(element)
@@ -446,7 +458,7 @@ class FluentParser:
         return trimmed
 
     @with_span
-    def get_text_element(self, ps):
+    def get_text_element(self, ps: FluentParserStream) -> ast.TextElement:
         buf = ''
 
         while ps.current_char:
@@ -463,7 +475,7 @@ class FluentParser:
 
         return ast.TextElement(buf)
 
-    def get_escape_sequence(self, ps):
+    def get_escape_sequence(self, ps: FluentParserStream) -> str:
         next = ps.current_char
 
         if next == '\\' or next == '"':
@@ -478,7 +490,7 @@ class FluentParser:
 
         raise ParseError('E0025', next)
 
-    def get_unicode_escape_sequence(self, ps, u, digits):
+    def get_unicode_escape_sequence(self, ps: FluentParserStream, u: str, digits: int) -> str:
         ps.expect_char(u)
         sequence = ''
         for _ in range(digits):
@@ -490,7 +502,7 @@ class FluentParser:
         return f'\\{u}{sequence}'
 
     @with_span
-    def get_placeable(self, ps):
+    def get_placeable(self, ps: FluentParserStream) -> ast.Placeable:
         ps.expect_char('{')
         ps.skip_blank()
         expression = self.get_expression(ps)
@@ -498,7 +510,9 @@ class FluentParser:
         return ast.Placeable(expression)
 
     @with_span
-    def get_expression(self, ps):
+    def get_expression(self, ps: FluentParserStream) -> Union[ast.InlineExpression,
+                                                              ast.Placeable,
+                                                              ast.SelectExpression]:
         selector = self.get_inline_expression(ps)
 
         ps.skip_blank()
@@ -547,7 +561,7 @@ class FluentParser:
         return selector
 
     @with_span
-    def get_inline_expression(self, ps):
+    def get_inline_expression(self, ps: FluentParserStream) -> Union[ast.InlineExpression, ast.Placeable]:
         if ps.current_char == '{':
             return self.get_placeable(ps)
 
@@ -598,7 +612,9 @@ class FluentParser:
         raise ParseError('E0028')
 
     @with_span
-    def get_call_argument(self, ps):
+    def get_call_argument(self,
+                          ps: FluentParserStream
+                          ) -> Union[ast.InlineExpression, ast.NamedArgument, ast.Placeable]:
         exp = self.get_inline_expression(ps)
 
         ps.skip_blank()
@@ -616,10 +632,10 @@ class FluentParser:
         raise ParseError('E0009')
 
     @with_span
-    def get_call_arguments(self, ps):
-        positional = []
-        named = []
-        argument_names = set()
+    def get_call_arguments(self, ps: FluentParserStream) -> ast.CallArguments:
+        positional: List[Union[ast.InlineExpression, ast.Placeable]] = []
+        named: List[ast.NamedArgument] = []
+        argument_names: Set[str] = set()
 
         ps.expect_char('(')
         ps.skip_blank()
@@ -652,7 +668,7 @@ class FluentParser:
         return ast.CallArguments(positional, named)
 
     @with_span
-    def get_string(self, ps):
+    def get_string(self, ps: FluentParserStream) -> ast.StringLiteral:
         value = ''
 
         ps.expect_char('"')
@@ -674,7 +690,7 @@ class FluentParser:
         return ast.StringLiteral(value)
 
     @with_span
-    def get_literal(self, ps):
+    def get_literal(self, ps: FluentParserStream) -> Union[ast.NumberLiteral, ast.StringLiteral]:
         if ps.is_number_start():
             return self.get_number(ps)
         if ps.current_char == '"':

--- a/fluent.syntax/fluent/syntax/serializer.py
+++ b/fluent.syntax/fluent/syntax/serializer.py
@@ -82,6 +82,9 @@ class FluentSerializer:
 
 
 def serialize_comment(comment: Union[ast.Comment, ast.GroupComment, ast.ResourceComment], prefix: str = "#") -> str:
+    if not comment.content:
+        return f'{prefix}\n'
+
     prefixed = "\n".join([
         prefix if len(line) == 0 else f"{prefix} {line}"
         for line in comment.content.split("\n")
@@ -91,7 +94,7 @@ def serialize_comment(comment: Union[ast.Comment, ast.GroupComment, ast.Resource
 
 
 def serialize_junk(junk: ast.Junk) -> str:
-    return junk.content
+    return junk.content or ''
 
 
 def serialize_message(message: ast.Message) -> str:
@@ -165,6 +168,7 @@ def serialize_placeable(placeable: ast.Placeable) -> str:
         return "{{ {}}}".format(serialize_expression(expr))
     if isinstance(expr, ast.Expression):
         return "{{ {} }}".format(serialize_expression(expr))
+    raise Exception('Unknown expression type: {}'.format(type(expr)))
 
 
 def serialize_expression(expression: Union[ast.Expression, ast.Placeable]) -> str:

--- a/fluent.syntax/fluent/syntax/stream.py
+++ b/fluent.syntax/fluent/syntax/stream.py
@@ -1,4 +1,5 @@
-from typing import Callable, Literal, Union
+from typing import Callable, Union
+from typing_extensions import Literal
 from .errors import ParseError
 
 

--- a/fluent.syntax/fluent/syntax/stream.py
+++ b/fluent.syntax/fluent/syntax/stream.py
@@ -1,19 +1,20 @@
+from typing import Callable, Literal, Union
 from .errors import ParseError
 
 
 class ParserStream:
-    def __init__(self, string):
+    def __init__(self, string: str):
         self.string = string
         self.index = 0
         self.peek_offset = 0
 
-    def get(self, offset):
+    def get(self, offset: int) -> Union[str, None]:
         try:
             return self.string[offset]
         except IndexError:
             return None
 
-    def char_at(self, offset):
+    def char_at(self, offset: int) -> Union[str, None]:
         # When the cursor is at CRLF, return LF but don't move the cursor. The
         # cursor still points to the EOL position, which in this case is the
         # beginning of the compound CRLF sequence. This ensures slices of
@@ -25,14 +26,14 @@ class ParserStream:
         return self.get(offset)
 
     @property
-    def current_char(self):
+    def current_char(self) -> Union[str, None]:
         return self.char_at(self.index)
 
     @property
-    def current_peek(self):
+    def current_peek(self) -> Union[str, None]:
         return self.char_at(self.index + self.peek_offset)
 
-    def next(self):
+    def next(self) -> Union[str, None]:
         self.peek_offset = 0
         # Skip over CRLF as if it was a single character.
         if self.get(self.index) == '\r' \
@@ -41,7 +42,7 @@ class ParserStream:
         self.index += 1
         return self.get(self.index)
 
-    def peek(self):
+    def peek(self) -> Union[str, None]:
         # Skip over CRLF as if it was a single character.
         if self.get(self.index + self.peek_offset) == '\r' \
                 and self.get(self.index + self.peek_offset + 1) == '\n':
@@ -49,10 +50,10 @@ class ParserStream:
         self.peek_offset += 1
         return self.get(self.index + self.peek_offset)
 
-    def reset_peek(self, offset=0):
+    def reset_peek(self, offset: int = 0) -> None:
         self.peek_offset = offset
 
-    def skip_to_peek(self):
+    def skip_to_peek(self) -> None:
         self.index += self.peek_offset
         self.peek_offset = 0
 
@@ -64,18 +65,18 @@ SPECIAL_LINE_START_CHARS = ('}', '.', '[', '*')
 
 class FluentParserStream(ParserStream):
 
-    def peek_blank_inline(self):
+    def peek_blank_inline(self) -> str:
         start = self.index + self.peek_offset
         while self.current_peek == ' ':
             self.peek()
         return self.string[start:self.index + self.peek_offset]
 
-    def skip_blank_inline(self):
+    def skip_blank_inline(self) -> str:
         blank = self.peek_blank_inline()
         self.skip_to_peek()
         return blank
 
-    def peek_blank_block(self):
+    def peek_blank_block(self) -> str:
         blank = ""
         while True:
             line_start = self.peek_offset
@@ -94,27 +95,27 @@ class FluentParserStream(ParserStream):
             self.reset_peek(line_start)
             return blank
 
-    def skip_blank_block(self):
+    def skip_blank_block(self) -> str:
         blank = self.peek_blank_block()
         self.skip_to_peek()
         return blank
 
-    def peek_blank(self):
+    def peek_blank(self) -> None:
         while self.current_peek in (" ", EOL):
             self.peek()
 
-    def skip_blank(self):
+    def skip_blank(self) -> None:
         self.peek_blank()
         self.skip_to_peek()
 
-    def expect_char(self, ch):
+    def expect_char(self, ch: str) -> Literal[True]:
         if self.current_char == ch:
             self.next()
             return True
 
         raise ParseError('E0003', ch)
 
-    def expect_line_end(self):
+    def expect_line_end(self) -> Literal[True]:
         if self.current_char is EOF:
             # EOF is a valid line end in Fluent.
             return True
@@ -126,29 +127,29 @@ class FluentParserStream(ParserStream):
         # Unicode Character 'SYMBOL FOR NEWLINE' (U+2424)
         raise ParseError('E0003', '\u2424')
 
-    def take_char(self, f):
+    def take_char(self, f: Callable[[str], bool]) -> Union[str, Literal[False], None]:
         ch = self.current_char
-        if ch is EOF:
+        if ch is None:
             return EOF
         if f(ch):
             self.next()
             return ch
         return False
 
-    def is_char_id_start(self, ch):
-        if ch is EOF:
+    def is_char_id_start(self, ch: Union[str, None]) -> bool:
+        if ch is None:
             return False
 
         cc = ord(ch)
         return (cc >= 97 and cc <= 122) or \
                (cc >= 65 and cc <= 90)
 
-    def is_identifier_start(self):
+    def is_identifier_start(self) -> bool:
         return self.is_char_id_start(self.current_peek)
 
-    def is_number_start(self):
+    def is_number_start(self) -> bool:
         ch = self.peek() if self.current_char == '-' else self.current_char
-        if ch is EOF:
+        if ch is None:
             self.reset_peek()
             return False
 
@@ -157,17 +158,17 @@ class FluentParserStream(ParserStream):
         self.reset_peek()
         return is_digit
 
-    def is_char_pattern_continuation(self, ch):
+    def is_char_pattern_continuation(self, ch: Union[str, None]) -> bool:
         if ch is EOF:
             return False
 
         return ch not in SPECIAL_LINE_START_CHARS
 
-    def is_value_start(self):
+    def is_value_start(self) -> bool:
         # Inline Patterns may start with any char.
         return self.current_peek is not EOF and self.current_peek != EOL
 
-    def is_value_continuation(self):
+    def is_value_continuation(self) -> bool:
         column1 = self.peek_offset
         self.peek_blank_inline()
 
@@ -188,7 +189,7 @@ class FluentParserStream(ParserStream):
     #  0 - comment
     #  1 - group comment
     #  2 - resource comment
-    def is_next_line_comment(self, level=-1):
+    def is_next_line_comment(self, level: int = -1) -> bool:
         if self.current_peek != EOL:
             return False
 
@@ -210,7 +211,7 @@ class FluentParserStream(ParserStream):
         self.reset_peek()
         return False
 
-    def is_variant_start(self):
+    def is_variant_start(self) -> bool:
         current_peek_offset = self.peek_offset
         if self.current_peek == '*':
             self.peek()
@@ -221,10 +222,10 @@ class FluentParserStream(ParserStream):
         self.reset_peek(current_peek_offset)
         return False
 
-    def is_attribute_start(self):
+    def is_attribute_start(self) -> bool:
         return self.current_peek == '.'
 
-    def skip_to_next_entry_start(self, junk_start):
+    def skip_to_next_entry_start(self, junk_start: int) -> None:
         last_newline = self.string.rfind(EOL, 0, self.index)
         if junk_start < last_newline:
             # Last seen newline is _after_ the junk start. It's safe to rewind
@@ -248,7 +249,7 @@ class FluentParserStream(ParserStream):
             if (first, peek) == ('/', '/') or (first, peek) == ('[', '['):
                 break
 
-    def take_id_start(self):
+    def take_id_start(self) -> Union[str, None]:
         if self.is_char_id_start(self.current_char):
             ret = self.current_char
             self.next()
@@ -256,8 +257,8 @@ class FluentParserStream(ParserStream):
 
         raise ParseError('E0004', 'a-zA-Z')
 
-    def take_id_char(self):
-        def closure(ch):
+    def take_id_char(self) -> Union[str, Literal[False], None]:
+        def closure(ch: str) -> bool:
             cc = ord(ch)
             return ((cc >= 97 and cc <= 122) or
                     (cc >= 65 and cc <= 90) or
@@ -265,14 +266,14 @@ class FluentParserStream(ParserStream):
                     cc == 95 or cc == 45)
         return self.take_char(closure)
 
-    def take_digit(self):
-        def closure(ch):
+    def take_digit(self) -> Union[str, Literal[False], None]:
+        def closure(ch: str) -> bool:
             cc = ord(ch)
             return (cc >= 48 and cc <= 57)
         return self.take_char(closure)
 
-    def take_hex_digit(self):
-        def closure(ch):
+    def take_hex_digit(self) -> Union[str, Literal[False], None]:
+        def closure(ch: str) -> bool:
             cc = ord(ch)
             return (
                 (cc >= 48 and cc <= 57)   # 0-9

--- a/fluent.syntax/fluent/syntax/visitor.py
+++ b/fluent.syntax/fluent/syntax/visitor.py
@@ -25,7 +25,7 @@ class Visitor:
         visit(node)
 
     def generic_visit(self, node: BaseNode) -> None:
-        for _propname, propvalue in vars(node).items():
+        for propvalue in vars(node).values():
             self.visit(propvalue)
 
 

--- a/fluent.syntax/fluent/syntax/visitor.py
+++ b/fluent.syntax/fluent/syntax/visitor.py
@@ -1,4 +1,5 @@
-from .ast import BaseNode
+from typing import Any, List
+from .ast import BaseNode, Node
 
 
 class Visitor:
@@ -11,7 +12,8 @@ class Visitor:
     If you want to still descend into the children of the node, call
     `generic_visit` of the superclass.
     '''
-    def visit(self, node):
+
+    def visit(self, node: Any) -> None:
         if isinstance(node, list):
             for child in node:
                 self.visit(child)
@@ -22,8 +24,8 @@ class Visitor:
         visit = getattr(self, f'visit_{nodename}', self.generic_visit)
         visit(node)
 
-    def generic_visit(self, node):
-        for propname, propvalue in vars(node).items():
+    def generic_visit(self, node: BaseNode) -> None:
+        for _propname, propvalue in vars(node).items():
             self.visit(propvalue)
 
 
@@ -35,7 +37,8 @@ class Transformer(Visitor):
     If you need to keep the original AST around, pass
     a `node.clone()` to the transformer.
     '''
-    def visit(self, node):
+
+    def visit(self, node: Any) -> Any:
         if not isinstance(node, BaseNode):
             return node
 
@@ -43,10 +46,10 @@ class Transformer(Visitor):
         visit = getattr(self, f'visit_{nodename}', self.generic_visit)
         return visit(node)
 
-    def generic_visit(self, node):
+    def generic_visit(self, node: Node) -> Node:  # type: ignore
         for propname, propvalue in vars(node).items():
             if isinstance(propvalue, list):
-                new_vals = []
+                new_vals: List[Any] = []
                 for child in propvalue:
                     new_val = self.visit(child)
                     if new_val is not None:

--- a/fluent.syntax/setup.cfg
+++ b/fluent.syntax/setup.cfg
@@ -12,3 +12,6 @@ max-line-length=120
 line_length=120
 skip_glob=.tox
 not_skip=__init__.py
+
+[mypy]
+strict = True

--- a/fluent.syntax/setup.py
+++ b/fluent.syntax/setup.py
@@ -1,8 +1,8 @@
-from setuptools import setup, find_namespace_packages
-import os
+from os import path
+from setuptools import setup
 
-this_directory = os.path.abspath(os.path.dirname(__file__))
-with open(os.path.join(this_directory, 'README.rst'), 'rb') as f:
+this_directory = path.abspath(path.dirname(__file__))
+with open(path.join(this_directory, 'README.rst'), 'rb') as f:
     long_description = f.read().decode('utf-8')
 
 setup(name='fluent.syntax',
@@ -24,6 +24,7 @@ setup(name='fluent.syntax',
           'Programming Language :: Python :: 3.9',
           'Programming Language :: Python :: 3 :: Only',
       ],
-      packages=find_namespace_packages(include=['fluent.*']),
+      packages=['fluent.syntax'],
+      package_data={'fluent.syntax': ['py.typed']},
       test_suite='tests.syntax'
       )

--- a/fluent.syntax/setup.py
+++ b/fluent.syntax/setup.py
@@ -26,5 +26,8 @@ setup(name='fluent.syntax',
       ],
       packages=['fluent.syntax'],
       package_data={'fluent.syntax': ['py.typed']},
+      install_requires=[
+          'typing-extensions>=3.7,<5'
+      ],
       test_suite='tests.syntax'
       )

--- a/fluent.syntax/tox.ini
+++ b/fluent.syntax/tox.ini
@@ -7,4 +7,6 @@ skipsdist=True
 [testenv]
 setenv =
     PYTHONPATH = {toxinidir}
+deps =
+     typing-extensions==3.7
 commands = ./runtests.py


### PR DESCRIPTION
Fixes #165 

The work here is split into commits that may be easier to review separately. The internal hints for the runtime resolver and compiler are pretty weak, as the base implementation is making explicit use of the language being fundamentally untyped.

The bugs that are fixed are all various sorts of corner cases that the code didn't account for previously; the errors tend to follow similar cases in fluent.js.

While adding the types I used both mypy and pylance; the added CI tests only apply `mypy --strict` as the strict-mode pylance checks don't all pass (mostly due to using `Unknown` values in places that accept `Any`).