### PR TITLE
Improve typing

### DIFF
--- a/.github/workflows/fluent.runtime.yml
+++ b/.github/workflows/fluent.runtime.yml
@@ -58,7 +58,7 @@ jobs:
           python -m pip install wheel
           python -m pip install --upgrade pip
           python -m pip install .
-          python -m pip install flake8==6 mypy==1 types-babel types-pytz
+          python -m pip install flake8==6 mypy==1.1.1 types-babel types-pytz
       - name: Install latest fluent.syntax
         working-directory: ./fluent.syntax
         run: |

--- a/.github/workflows/fluent.syntax.yml
+++ b/.github/workflows/fluent.syntax.yml
@@ -52,7 +52,7 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           python -m pip install .
-          python -m pip install flake8==6 mypy==1
+          python -m pip install flake8==6 mypy==1.1.1
       - name: flake8
         working-directory: ./fluent.syntax
         run: |

--- a/fluent.runtime/fluent/runtime/__init__.py
+++ b/fluent.runtime/fluent/runtime/__init__.py
@@ -2,8 +2,7 @@ from fluent.syntax import FluentParser
 from fluent.syntax.ast import Resource
 
 from .bundle import FluentBundle
-from .fallback import FluentLocalization, AbstractResourceLoader, FluentResourceLoader
-
+from .fallback import AbstractResourceLoader, FluentLocalization, FluentResourceLoader
 
 __all__ = [
     'FluentLocalization',

--- a/fluent.runtime/fluent/runtime/builtins.py
+++ b/fluent.runtime/fluent/runtime/builtins.py
@@ -1,8 +1,10 @@
 from typing import Any, Callable, Dict
+from typing_extensions import Final
+
 from .types import FluentType, fluent_date, fluent_number
 
-NUMBER = fluent_number
-DATETIME = fluent_date
+NUMBER: Final = fluent_number
+DATETIME: Final = fluent_date
 
 
 BUILTINS: Dict[str, Callable[[Any], FluentType]] = {

--- a/fluent.runtime/fluent/runtime/bundle.py
+++ b/fluent.runtime/fluent/runtime/bundle.py
@@ -1,9 +1,9 @@
+from typing import TYPE_CHECKING, Any, Callable, Dict, List, Sequence, Tuple, Union, cast
+from typing_extensions import Literal
+
 import babel
 import babel.numbers
 import babel.plural
-from typing import Any, Callable, Dict, List, TYPE_CHECKING, Tuple, Union, cast
-from typing_extensions import Literal
-
 from fluent.syntax import ast as FTL
 
 from .builtins import BUILTINS
@@ -12,6 +12,8 @@ from .resolver import CurrentEnvironment, Message, Pattern, ResolverEnvironment
 from .utils import native_to_fluent
 
 if TYPE_CHECKING:
+    from _typeshed import SupportsItems, SupportsKeysAndGetItem
+
     from .types import FluentNone, FluentType
 
 PluralCategory = Literal['zero', 'one', 'two', 'few', 'many', 'other']
@@ -33,8 +35,8 @@ class FluentBundle:
     """
 
     def __init__(self,
-                 locales: List[str],
-                 functions: Union[Dict[str, Callable[[Any], 'FluentType']], None] = None,
+                 locales: Sequence[str],
+                 functions: Union['SupportsKeysAndGetItem[str, Callable[[Any], FluentType]]', None] = None,
                  use_isolating: bool = True):
         self.locales = locales
         self._functions = {**BUILTINS, **(functions or {})}
@@ -79,10 +81,10 @@ class FluentBundle:
 
     def format_pattern(self,
                        pattern: Pattern,
-                       args: Union[Dict[str, Any], None] = None
+                       args: Union['SupportsItems[str, Any]', None] = None
                        ) -> Tuple[Union[str, 'FluentNone'], List[Exception]]:
         if args is not None:
-            fluent_args = {
+            fluent_args: Dict[str, Any] = {
                 argname: native_to_fluent(argvalue)
                 for argname, argvalue in args.items()
             }

--- a/fluent.runtime/fluent/runtime/prepare.py
+++ b/fluent.runtime/fluent/runtime/prepare.py
@@ -1,5 +1,7 @@
-from typing import Any, Dict, List
+from typing import Any, Dict, Sequence
+
 from fluent.syntax import ast as FTL
+
 from . import resolver
 
 
@@ -29,7 +31,7 @@ class Compiler:
             return expression
         return resolver.Placeable(expression=expression, **kwargs)
 
-    def compile_Pattern(self, _: Any, elements: List[Any], **kwargs: Any) -> Any:
+    def compile_Pattern(self, _: Any, elements: Sequence[Any], **kwargs: Any) -> Any:
         if len(elements) == 1 and isinstance(elements[0], resolver.Placeable):
             # Don't isolate isolated placeables
             return resolver.NeverIsolatingPlaceable(elements[0].expression)

--- a/fluent.runtime/fluent/runtime/resolver.py
+++ b/fluent.runtime/fluent/runtime/resolver.py
@@ -1,10 +1,12 @@
-import attr
 import contextlib
-from typing import Any, Dict, Generator, List, Set, TYPE_CHECKING, Union, cast
+from typing import TYPE_CHECKING, Any, Dict, Iterable, Iterator, List, Mapping, Sequence, Set, Union, cast
+from typing_extensions import Final, Self
 
+import attr
 from fluent.syntax import ast as FTL
+
 from .errors import FluentCyclicReferenceError, FluentFormatError, FluentReferenceError
-from .types import FluentType, FluentNone, FluentInt, FluentFloat
+from .types import FluentFloat, FluentInt, FluentNone, FluentType
 from .utils import reference_to_id, unknown_reference_error_obj
 
 if TYPE_CHECKING:
@@ -27,7 +29,7 @@ modifyable state in the resolver environment.
 
 
 # Prevent expansion of too long placeables, for memory DOS protection
-MAX_PART_LENGTH = 2500
+MAX_PART_LENGTH: Final = 2500
 
 
 @attr.s
@@ -56,7 +58,7 @@ class ResolverEnvironment:
     current: CurrentEnvironment = attr.ib(factory=CurrentEnvironment)
 
     @contextlib.contextmanager
-    def modified(self, **replacements: Any) -> Generator['ResolverEnvironment', None, None]:
+    def modified(self, **replacements: Any) -> Iterator[Self]:
         """
         Context manager that modifies the 'current' attribute of the
         environment, restoring the old data at the end.
@@ -68,7 +70,9 @@ class ResolverEnvironment:
         yield self
         self.current = old_current
 
-    def modified_for_term_reference(self, args: Union[Dict[str, Any], None] = None) -> Any:
+    def modified_for_term_reference(self,
+                                    args: Union[Mapping[str, Any], None] = None
+                                    ) -> 'contextlib._GeneratorContextManager[Self]':
         return self.modified(args=args if args is not None else {},
                              error_for_missing_arg=False)
 
@@ -99,7 +103,7 @@ class Message(FTL.Entry, BaseResolver):
     def __init__(self,
                  id: 'Identifier',
                  value: Union['Pattern', None] = None,
-                 attributes: Union[List['Attribute'], None] = None,
+                 attributes: Union[Iterable['Attribute'], None] = None,
                  comment: Any = None,
                  **kwargs: Any):
         super().__init__(**kwargs)
@@ -116,7 +120,7 @@ class Term(FTL.Entry, BaseResolver):
     def __init__(self,
                  id: 'Identifier',
                  value: 'Pattern',
-                 attributes: Union[List['Attribute'], None] = None,
+                 attributes: Union[Iterable['Attribute'], None] = None,
                  comment: Any = None,
                  **kwargs: Any):
         super().__init__(**kwargs)
@@ -129,7 +133,7 @@ class Pattern(FTL.Pattern, BaseResolver):
     # Prevent messages with too many sub parts, for CPI DOS protection
     MAX_PARTS = 1000
 
-    elements: List[Union['TextElement', 'Placeable']]  # type: ignore
+    elements: Sequence[Union['TextElement', 'Placeable']]
 
     def __init__(self, *args: Any, **kwargs: Any):
         super().__init__(*args, **kwargs)
@@ -198,14 +202,14 @@ class StringLiteral(FTL.StringLiteral, Literal):
 
 
 class NumberLiteral(FTL.NumberLiteral, BaseResolver):
-    value: Union[FluentFloat, FluentInt]  # type: ignore
+    value: Union[FluentFloat, FluentInt]  # type: ignore[assignment]
 
     def __init__(self, value: str, **kwargs: Any):
         super().__init__(value, **kwargs)
         if '.' in cast(str, self.value):
-            self.value = FluentFloat(self.value)
+            self.value = FluentFloat(cast(str, self.value))
         else:
-            self.value = FluentInt(self.value)
+            self.value = FluentInt(cast(str, self.value))
 
     def __call__(self, env: ResolverEnvironment) -> Union[FluentFloat, FluentInt]:
         return self.value
@@ -285,7 +289,7 @@ class Attribute(FTL.Attribute, BaseResolver):
 
 class SelectExpression(FTL.SelectExpression, BaseResolver):
     selector: 'InlineExpression'
-    variants: List['Variant']  # type: ignore
+    variants: Sequence['Variant']
 
     def __call__(self, env: ResolverEnvironment) -> Union[str, FluentNone]:
         key = self.selector(env)
@@ -340,8 +344,8 @@ class Identifier(FTL.Identifier, BaseResolver):
 
 
 class CallArguments(FTL.CallArguments, BaseResolver):
-    positional: List[Union['InlineExpression', Placeable]]  # type: ignore
-    named: List['NamedArgument']  # type: ignore
+    positional: Sequence[Union['InlineExpression', Placeable]]
+    named: Sequence['NamedArgument']
 
 
 class FunctionReference(FTL.FunctionReference, BaseResolver):

--- a/fluent.runtime/fluent/runtime/utils.py
+++ b/fluent.runtime/fluent/runtime/utils.py
@@ -1,14 +1,48 @@
 from datetime import date, datetime
 from decimal import Decimal
-from typing import Any, Union
+from typing import Any, TypeVar, Union, overload
+from typing_extensions import Final
 
 from fluent.syntax.ast import MessageReference, TermReference
 
-from .types import FluentInt, FluentFloat, FluentDecimal, FluentDate, FluentDateTime
 from .errors import FluentReferenceError
+from .types import FluentDate, FluentDateTime, FluentDecimal, FluentFloat, FluentInt
 
-TERM_SIGIL = '-'
-ATTRIBUTE_SEPARATOR = '.'
+TERM_SIGIL: Final = '-'
+ATTRIBUTE_SEPARATOR: Final = '.'
+
+
+_T = TypeVar('_T')
+
+
+@overload
+def native_to_fluent(val: int) -> FluentInt:  # type: ignore[misc]
+    ...
+
+
+@overload
+def native_to_fluent(val: float) -> FluentFloat:  # type: ignore[misc]
+    ...
+
+
+@overload
+def native_to_fluent(val: Decimal) -> FluentDecimal:  # type: ignore[misc]
+    ...
+
+
+@overload
+def native_to_fluent(val: datetime) -> FluentDateTime:  # type: ignore[misc]
+    ...
+
+
+@overload
+def native_to_fluent(val: date) -> FluentDate:  # type: ignore[misc]
+    ...
+
+
+@overload
+def native_to_fluent(val: _T) -> _T:
+    ...
 
 
 def native_to_fluent(val: Any) -> Any:

--- a/fluent.runtime/setup.cfg
+++ b/fluent.runtime/setup.cfg
@@ -12,6 +12,8 @@ max-line-length=120
 line_length=120
 skip_glob=.tox
 not_skip=__init__.py
+extra_standard_library=typing_extensions, _typeshed
 
 [mypy]
-strict = True
+strict=True
+python_version=3.6

--- a/fluent.runtime/setup.py
+++ b/fluent.runtime/setup.py
@@ -33,7 +33,7 @@ setup(name='fluent.runtime',
           'attrs',
           'babel',
           'pytz',
-          'typing-extensions>=3.7,<5'
+          'typing-extensions>=4.0,<4.2'
       ],
       test_suite='tests',
       )

--- a/fluent.syntax/fluent/syntax/parser.py
+++ b/fluent.syntax/fluent/syntax/parser.py
@@ -1,13 +1,14 @@
 import re
-from typing import Any, Callable, List, Set, TypeVar, Union, cast
+from typing import Any, Callable, Iterable, List, Set, TypeVar, Union, cast
+
 from . import ast
-from .stream import EOL, FluentParserStream
 from .errors import ParseError
+from .stream import EOL, FluentParserStream
 
-R = TypeVar("R", bound=ast.SyntaxNode)
+WithSpanFunc = TypeVar("WithSpanFunc", bound=Callable[..., ast.SyntaxNode])
 
 
-def with_span(fn: Callable[..., R]) -> Callable[..., R]:
+def with_span(fn: WithSpanFunc) -> WithSpanFunc:
     def decorated(self: 'FluentParser', ps: FluentParserStream, *args: Any, **kwargs: Any) -> Any:
         if not self.with_spans:
             return fn(self, ps, *args, **kwargs)
@@ -24,7 +25,7 @@ def with_span(fn: Callable[..., R]) -> Callable[..., R]:
         node.add_span(start, end)
         return node
 
-    return decorated
+    return cast(WithSpanFunc, decorated)
 
 
 class FluentParser:
@@ -412,7 +413,7 @@ class FluentParser:
             self.add_span(start, end)
 
     def dedent(self,
-               elements: List[Union[ast.TextElement, ast.Placeable, Indent]],
+               elements: Iterable[Union[ast.TextElement, ast.Placeable, Indent]],
                common_indent: int
                ) -> List[Union[ast.TextElement, ast.Placeable]]:
         '''Dedent a list of elements by removing the maximum common indent from

--- a/fluent.syntax/fluent/syntax/serializer.py
+++ b/fluent.syntax/fluent/syntax/serializer.py
@@ -1,4 +1,5 @@
 from typing import List, Union
+
 from . import ast
 
 

--- a/fluent.syntax/fluent/syntax/stream.py
+++ b/fluent.syntax/fluent/syntax/stream.py
@@ -1,5 +1,6 @@
 from typing import Callable, Union
-from typing_extensions import Literal
+from typing_extensions import Final, Literal
+
 from .errors import ParseError
 
 
@@ -59,9 +60,9 @@ class ParserStream:
         self.peek_offset = 0
 
 
-EOL = '\n'
-EOF = None
-SPECIAL_LINE_START_CHARS = ('}', '.', '[', '*')
+EOL: Final = '\n'
+EOF: Final = None
+SPECIAL_LINE_START_CHARS: Final = ('}', '.', '[', '*')
 
 
 class FluentParserStream(ParserStream):

--- a/fluent.syntax/fluent/syntax/visitor.py
+++ b/fluent.syntax/fluent/syntax/visitor.py
@@ -1,5 +1,8 @@
-from typing import Any, List
-from .ast import BaseNode, Node
+from typing import Any, List, TypeVar
+
+from .ast import BaseNode
+
+Node = TypeVar("Node", bound=BaseNode)
 
 
 class Visitor:
@@ -46,7 +49,7 @@ class Transformer(Visitor):
         visit = getattr(self, f'visit_{nodename}', self.generic_visit)
         return visit(node)
 
-    def generic_visit(self, node: Node) -> Node:  # type: ignore
+    def generic_visit(self, node: Node) -> Node:  # type: ignore[override]
         for propname, propvalue in vars(node).items():
             if isinstance(propvalue, list):
                 new_vals: List[Any] = []

--- a/fluent.syntax/setup.cfg
+++ b/fluent.syntax/setup.cfg
@@ -12,6 +12,8 @@ max-line-length=120
 line_length=120
 skip_glob=.tox
 not_skip=__init__.py
+extra_standard_library=typing_extensions, _typeshed
 
 [mypy]
-strict = True
+strict=True
+python_version=3.6

--- a/fluent.syntax/setup.py
+++ b/fluent.syntax/setup.py
@@ -27,7 +27,7 @@ setup(name='fluent.syntax',
       packages=['fluent.syntax'],
       package_data={'fluent.syntax': ['py.typed']},
       install_requires=[
-          'typing-extensions>=3.7,<5'
+          'typing-extensions>=4.0,<4.2'
       ],
       test_suite='tests.syntax'
       )


### PR DESCRIPTION
I've done the following:

* Bumped the minimum version of `typing_extensions` in order to use `Self`
* Updated workflows to use `mypy` 1.1.1 to type check the project
* Updated parameters to use protocols (`Mapping`, `Sequence`, `Iterable`, etc.) where possible
* Marked constants as `Final`
* Improved typing of `merge_options()` so it can be used by consumers
* Added overloads for `fluent_number()` and `fluent_date()`
* Used `Iterator[]` for iterators rather than the more complex `Generator[]`
* Ran `isort` on `fluent.syntax` and `fluent.runtime`