### PR TITLE
Prevent package from installing on Python < 3.6

### DIFF
--- a/fluent.runtime/setup.py
+++ b/fluent.runtime/setup.py
@@ -28,6 +28,7 @@ setup(name='fluent.runtime',
       packages=['fluent.runtime'],
       package_data={'fluent.runtime': ['py.typed']},
       # These should also be duplicated in tox.ini and /.github/workflows/fluent.runtime.yml
+      python_requires='>=3.6',
       install_requires=[
           'fluent.syntax>=0.17,<0.20',
           'attrs',


### PR DESCRIPTION
#163 dropped support of Python < 3.6, but haven't set minimal Python version in setup.py. Currently only classifiers are set, which are just additional information used for search, these values are not checked during package installation.

Adding `python_requires` to `setup.py` to allow package managers to check that package is compatible only with Python >= 3.6.

fix #188