### PR TITLE
Fix duplicate 'type' key in dictionary

### DIFF
--- a/fluent.syntax/tests/syntax/test_entry.py
+++ b/fluent.syntax/tests/syntax/test_entry.py
@@ -48,7 +48,6 @@ class TestParseEntry(unittest.TestCase):
             "type": "Message",
             "id": {"name": "foo", "span": None, "type": "Identifier"},
             "span": None,
-            "type": "Message",
         }
 
         message = self.parser.parse_entry(dedent_ftl(input))


### PR DESCRIPTION
Spotted with `ruff`