### PR TITLE
Respect the `with_spans` parser option for annotations

### DIFF
--- a/fluent.syntax/fluent/syntax/parser.py
+++ b/fluent.syntax/fluent/syntax/parser.py
@@ -133,7 +133,8 @@ class FluentParser:
             annot = ast.Annotation(
                 err.code, list(err.args) if err.args else None, err.message
             )
-            annot.add_span(error_index, error_index)
+            if self.with_spans:
+                annot.add_span(error_index, error_index)
             junk.add_annotation(annot)
             return junk
 

--- a/fluent.syntax/tests/syntax/test_entry.py
+++ b/fluent.syntax/tests/syntax/test_entry.py
@@ -65,7 +65,7 @@ class TestParseEntry(unittest.TestCase):
                     "arguments": ["="],
                     "code": "E0003",
                     "message": 'Expected token: "="',
-                    "span": {"end": 23, "start": 23, "type": "Span"},
+                    "span": None,
                     "type": "Annotation",
                 }
             ],
@@ -111,7 +111,7 @@ class TestParseEntry(unittest.TestCase):
                     "arguments": [" "],
                     "code": "E0003",
                     "message": 'Expected token: " "',
-                    "span": {"end": 21, "start": 21, "type": "Span"},
+                    "span": None,
                     "type": "Annotation",
                 }
             ],

--- a/fluent.syntax/tests/syntax/test_structure.py
+++ b/fluent.syntax/tests/syntax/test_structure.py
@@ -12,23 +12,47 @@ def read_file(path):
     return text
 
 
+def without_spans(expected):
+    """
+    Given an expected JSON fragment with span information, recursively replace all of the spans
+    with None.
+    """
+    if isinstance(expected, dict):
+        result = {}
+        for key, value in expected.items():
+            if key == "span":
+                result[key] = None
+            else:
+                result[key] = without_spans(value)
+
+        return result
+    elif isinstance(expected, list):
+        return [without_spans(item) for item in expected]
+    else:
+        # We have been passed something which would not have span information in it
+        return expected
+
+
 fixtures = os.path.join(os.path.dirname(__file__), "fixtures_structure")
 
 
 class TestStructureMeta(type):
     def __new__(mcs, name, bases, attrs):
 
-        def gen_test(file_name):
+        def gen_test(file_name, with_spans):
             def test(self):
                 ftl_path = os.path.join(fixtures, file_name + ".ftl")
                 ast_path = os.path.join(fixtures, file_name + ".json")
 
                 source = read_file(ftl_path)
-                expected = read_file(ast_path)
+                expected = json.loads(read_file(ast_path))
 
-                ast = parse(source)
+                if not with_spans:
+                    expected = without_spans(expected)
 
-                self.assertEqual(ast.to_json(), json.loads(expected))
+                ast = parse(source, with_spans=with_spans)
+
+                self.assertEqual(ast.to_json(), expected)
 
             return test
 
@@ -38,8 +62,8 @@ class TestStructureMeta(type):
             if ext != ".ftl":
                 continue
 
-            test_name = f"test_{file_name}"
-            attrs[test_name] = gen_test(file_name)
+            attrs[f"test_{file_name}_with_spans"] = gen_test(file_name, with_spans=True)
+            attrs[f"test_{file_name}_without_spans"] = gen_test(file_name, with_spans=False)
 
         return type.__new__(mcs, name, bases, attrs)
 


### PR DESCRIPTION
This PR contains a small change to stop adding span information to `Annotation` elements when `with_spans` is set to `False` for the parser.

I've pulled this into its own PR because it wasn't obvious whether this behaviour was intentional or not (I could see an argument that annotations are a bit useless without span information). If this isn't needed, I'm happy to close this PR.

Note that the broken tests are unrelated to this PR, and are fixed in https://github.com/projectfluent/python-fluent/pull/203.