### PR TITLE
Update tests to support Babel 2.15.0

### DIFF
--- a/fluent.runtime/tests/test_types.py
+++ b/fluent.runtime/tests/test_types.py
@@ -235,7 +235,7 @@ class TestFluentDate(unittest.TestCase):
         fd1b = fluent_date(dt1, dateStyle="full", timeStyle="full")
         self.assertRegex(
             fd1b.format(en_GB),
-            "^Monday, 2 July 2018(,| at) 00:30:00 British Summer Time$",
+            "^Monday,? 2 July 2018(,| at) 00:30:00 British Summer Time$",
         )
         fd1c = fluent_date(dt1, dateStyle="short")
         self.assertEqual(fd1c.format(en_GB), "02/07/2018")
@@ -253,7 +253,7 @@ class TestFluentDate(unittest.TestCase):
         )
         self.assertRegex(
             fd2b.format(en_GB),
-            "^Monday, 2 July 2018(,| at) 00:30:00 British Summer Time$",
+            "^Monday,? 2 July 2018(,| at) 00:30:00 British Summer Time$",
         )
         fd2c = fluent_date(dt2, dateStyle="short", timeZone="Europe/London")
         self.assertEqual(fd2c.format(en_GB), "02/07/2018")


### PR DESCRIPTION
As part of the Babel 2.15.0 release, an upgrade to CLDR 44 was included. The new CLDR version changes the date format for the en-GB locale to remove a comma in the full format.

This change updates the tests so that both the old and new formats can be handled. This is done instead of pinning babel to a lower version, since we just care that formatting takes place.

[Babel issue]: https://github.com/python-babel/babel/issues/1070
[CLDR 44 changes]: https://www.unicode.org/cldr/charts/44/delta/en.html#Formats%20-%20Standard%20-%20Date%20Formats