### PR TITLE
Fix test failures on windows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,7 +23,9 @@ jobs:
       - run: python -m flake8
       - run: python -m mypy fluent.syntax/fluent fluent.runtime/fluent
   test:
-    runs-on: ubuntu-latest
+    # Workaround Python 3.7 no longer supported https://github.com/actions/setup-python/issues/962#issuecomment-2414454450
+    #runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     strategy:
       matrix:
         python-version: [3.7, 3.8, 3.9, "3.10", 3.11, 3.12, pypy3.9, pypy3.10]

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,11 +23,10 @@ jobs:
       - run: python -m flake8
       - run: python -m mypy fluent.syntax/fluent fluent.runtime/fluent
   test:
-    # Workaround Python 3.7 no longer supported https://github.com/actions/setup-python/issues/962#issuecomment-2414454450
-    #runs-on: ubuntu-latest
-    runs-on: ubuntu-22.04
+    runs-on: ${{ matrix.os }}
     strategy:
       matrix:
+        os: [ubuntu-22.04, windows-2022]
         python-version: [3.7, 3.8, 3.9, "3.10", 3.11, 3.12, pypy3.9, pypy3.10]
     steps:
       - uses: actions/checkout@v4

--- a/fluent.runtime/tests/__init__.py
+++ b/fluent.runtime/tests/__init__.py
@@ -1,7 +1,0 @@
-import os
-
-
-# Unify path separator, default path separator on Windows is \ not /
-# Needed in test_falllback.py because it uses dict + string compare to make a virtual file structure
-def normalize_path(path):
-    return "/".join(os.path.split(path))

--- a/fluent.runtime/tests/__init__.py
+++ b/fluent.runtime/tests/__init__.py
@@ -1,0 +1,6 @@
+import os
+
+# Unify path separator, default path separator on Windows is \ not /
+# Needed because many tests uses dict + string compare to make a virtual file structure
+def normalize_path(path):
+    return "/".join(os.path.split(path))

--- a/fluent.runtime/tests/__init__.py
+++ b/fluent.runtime/tests/__init__.py
@@ -1,6 +1,7 @@
 import os
 
+
 # Unify path separator, default path separator on Windows is \ not /
-# Needed because many tests uses dict + string compare to make a virtual file structure
+# Needed in test_falllback.py because it uses dict + string compare to make a virtual file structure
 def normalize_path(path):
     return "/".join(os.path.split(path))

--- a/fluent.runtime/tests/test_fallback.py
+++ b/fluent.runtime/tests/test_fallback.py
@@ -9,13 +9,6 @@ from fluent.runtime import FluentLocalization, FluentResourceLoader
 
 ISFILE = os.path.isfile
 
-def show_bundle(bundle):
-    for name in ["one", "two", "three", "four", "five"]:
-        if bundle.has_message(name):
-            print(name + ":", bundle.format_pattern(bundle.get_message(name).value))
-        else:
-            print(name + ": Not present")
-
 
 class TestLocalization(unittest.TestCase):
     def test_init(self):
@@ -41,21 +34,17 @@ class TestLocalization(unittest.TestCase):
             ["de", "fr", "en"], ["one.ftl", "two.ftl"], FluentResourceLoader("{locale}")
         )
         # Curious
-        print("\ntest_bundles")
         bundles_gen = l10n._bundles()
         bundle_de = next(bundles_gen)
-        show_bundle(bundle_de)
         self.assertEqual(bundle_de.locales[0], "de")
         self.assertTrue(bundle_de.has_message("one"))
         self.assertTrue(bundle_de.has_message("two"))
         bundle_fr = next(bundles_gen)
-        show_bundle(bundle_fr)
         self.assertEqual(bundle_fr.locales[0], "fr")
         self.assertFalse(bundle_fr.has_message("one"))
         self.assertTrue(bundle_fr.has_message("three"))
         self.assertListEqual(list(l10n._bundles())[:2], [bundle_de, bundle_fr])
         bundle_en = next(bundles_gen)
-        show_bundle(bundle_en)
         self.assertEqual(bundle_en.locales[0], "en")
         self.assertEqual(l10n.format_value("one"), "in German")
         self.assertEqual(l10n.format_value("two"), "in German")

--- a/fluent.runtime/tests/test_fallback.py
+++ b/fluent.runtime/tests/test_fallback.py
@@ -27,7 +27,6 @@ class TestLocalization(unittest.TestCase):
             "en/one.ftl": "four = exists",
             "en/two.ftl": "five = exists",
         }
-        #isfile.side_effect = lambda p: p in data or ISFILE(p)
         isfile.side_effect = lambda p: normalize_path(p) in data or ISFILE(p)
         codecs_open.side_effect = lambda p, _, __: io.StringIO(data[normalize_path(p)])
         l10n = FluentLocalization(

--- a/fluent.runtime/tests/test_utils.py
+++ b/fluent.runtime/tests/test_utils.py
@@ -31,9 +31,9 @@ class TestFileSimulate(unittest.TestCase):
         """
         if expect_contents is None:
             self.assertFalse(os.path.isfile(filename),
-                             "Expected " + filename + " to not exist.")
+                             f"Expected {filename} to not exist.")
         else:
             self.assertTrue(os.path.isfile(filename),
-                            "Expected " + filename + " to exist.")
+                            f"Expected {filename} to exist.")
             self.assertEqual(codecs.open(filename, "r", "utf-8").read(),
                              expect_contents)

--- a/fluent.runtime/tests/test_utils.py
+++ b/fluent.runtime/tests/test_utils.py
@@ -22,6 +22,9 @@ class TestFileSimulate(unittest.TestCase):
             self.assertFileIs("en\\two.txt", "Two")
             self.assertFileIs("en/three.txt", None)
             self.assertFileIs("en\\three.txt", None)
+
+            with self.assertRaises(ValueError):
+                os.path.isfile("en/")
         patch_me(10, "b")
 
     def assertFileIs(self, filename, expect_contents):

--- a/fluent.runtime/tests/test_utils.py
+++ b/fluent.runtime/tests/test_utils.py
@@ -1,0 +1,39 @@
+import unittest
+from .utils import patch_files
+import os
+import codecs
+
+
+class TestFileSimulate(unittest.TestCase):
+    def test_basic(self):
+        @patch_files({
+            "the.txt": "The",
+            "en/one.txt": "One",
+            "en/two.txt": "Two"
+        })
+        def patch_me(a, b):
+            self.assertEqual(a, 10)
+            self.assertEqual(b, "b")
+            self.assertFileIs(os.path.basename(__file__), None)
+            self.assertFileIs("the.txt", "The")
+            self.assertFileIs("en/one.txt", "One")
+            self.assertFileIs("en\\one.txt", "One")
+            self.assertFileIs("en/two.txt", "Two")
+            self.assertFileIs("en\\two.txt", "Two")
+            self.assertFileIs("en/three.txt", None)
+            self.assertFileIs("en\\three.txt", None)
+        patch_me(10, "b")
+
+    def assertFileIs(self, filename, expect_contents):
+        """
+        expect_contents is None: Expect file does not exist
+        expect_contents is a str: Expect file contents to match
+        """
+        if expect_contents is None:
+            self.assertFalse(os.path.isfile(filename),
+                             "Expected " + filename + " to not exist.")
+        else:
+            self.assertTrue(os.path.isfile(filename),
+                            "Expected " + filename + " to exist.")
+            self.assertEqual(codecs.open(filename, "r", "utf-8").read(),
+                             expect_contents)

--- a/fluent.runtime/tests/test_utils.py
+++ b/fluent.runtime/tests/test_utils.py
@@ -27,7 +27,7 @@ class TestFileSimulate(unittest.TestCase):
     def assertFileIs(self, filename, expect_contents):
         """
         expect_contents is None: Expect file does not exist
-        expect_contents is a str: Expect file contents to match
+        expect_contents is a str: Expect file to exist and contents to match
         """
         if expect_contents is None:
             self.assertFalse(os.path.isfile(filename),
@@ -35,5 +35,5 @@ class TestFileSimulate(unittest.TestCase):
         else:
             self.assertTrue(os.path.isfile(filename),
                             f"Expected {filename} to exist.")
-            self.assertEqual(codecs.open(filename, "r", "utf-8").read(),
-                             expect_contents)
+            with codecs.open(filename, "r", "utf-8") as f:
+                self.assertEqual(f.read(), expect_contents)

--- a/fluent.runtime/tests/utils.py
+++ b/fluent.runtime/tests/utils.py
@@ -1,7 +1,7 @@
 """Utilities for testing."""
 
 import textwrap
-from pathlib import PurePath
+from pathlib import PureWindowsPath, PurePosixPath
 from unittest import mock
 from io import StringIO
 import functools
@@ -11,16 +11,21 @@ def dedent_ftl(text):
     return textwrap.dedent(f"{text.rstrip()}\n")
 
 
-# Unify path separator, default path separator on Windows is \ not /
-# Supports only relative paths
 # Needed in test_falllback.py because it uses dict + string compare to make a virtual file structure
-def _normalize_path(path):
+def _normalize_file_path(path):
     """Note: Does not support absolute paths or paths that
     contain '.' or '..' parts."""
-    path = PurePath(path)
-    if path.is_absolute() or "." in path.parts or ".." in path.parts:
+    # Cannot use os.path or PurePath, because they only recognize
+    # one kind of path separator
+    if PureWindowsPath(path).is_absolute() or PurePosixPath(path).is_absolute():
         raise ValueError(f"Unsupported path: {path}")
-    return "/".join(path.parts)
+    parts = path.replace("\\", "/").split("/")
+    if "." in parts or ".." in parts:
+        raise ValueError(f"Unsupported path: {path}")
+    if parts and parts[-1] == "":
+        # path ends with a trailing pathsep
+        raise ValueError(f"Path appears to be a directory, not a file: {path}")
+    return "/".join(parts)
 
 
 def patch_files(files: dict):
@@ -32,12 +37,12 @@ def patch_files(files: dict):
 
     The implementation may be changed to match the mechanism used.
     """
-    if files is None:
-        files = {}
+
+    # Here it is possible to validate file names, but skipped
 
     def then(func):
-        @mock.patch("os.path.isfile", side_effect=lambda p: _normalize_path(p) in files)
-        @mock.patch("codecs.open", side_effect=lambda p, _, __: StringIO(files[_normalize_path(p)]))
+        @mock.patch("os.path.isfile", side_effect=lambda p: _normalize_file_path(p) in files)
+        @mock.patch("codecs.open", side_effect=lambda p, _, __: StringIO(files[_normalize_file_path(p)]))
         @functools.wraps(func)  # Make ret look like func to later decorators
         def ret(*args, **kwargs):
             func(*args[:-2], **kwargs)

--- a/fluent.runtime/tests/utils.py
+++ b/fluent.runtime/tests/utils.py
@@ -18,25 +18,12 @@ def dedent_ftl(text):
 # Supports only relative paths
 # Needed in test_falllback.py because it uses dict + string compare to make a virtual file structure
 def _normalize_path(path):
+    """Note: Does not support absolute paths or paths that
+    contain '.' or '..' parts."""
     path = PurePath(path)
-    if path.is_absolute():
-        raise ValueError("Absolute paths are not supported in file simulation yet. ("
-                         + str(path) + ")")
-    if "." not in path.parts and ".." not in path.parts:
-        return "/".join(PurePath(path).parts)
-    else:
-        res_parts = []
-        length = len(path.parts)
-        i = 0
-        while i < length:
-            if path.parts[i] == ".":
-                i += 1
-            elif i < length - 1 and path.parts[i+1] == "..":
-                i += 2
-            else:
-                res_parts.append(path.parts[i])
-                i += 1
-        return "/".join(res_parts)
+    if path.is_absolute() or "." in path.parts or ".." in path.parts:
+        raise ValueError(f"Unsupported path: {path}")
+    return "/".join(path.parts)
 
 
 def patch_files(files: dict):

--- a/fluent.runtime/tests/utils.py
+++ b/fluent.runtime/tests/utils.py
@@ -1,5 +1,61 @@
+"""Utilities for testing.
+
+Import this module before patching libraries.
+"""
+
 import textwrap
+from pathlib import PurePath
+from unittest import mock
+from io import StringIO
+import functools
 
 
 def dedent_ftl(text):
     return textwrap.dedent(f"{text.rstrip()}\n")
+
+
+# Unify path separator, default path separator on Windows is \ not /
+# Supports only relative paths
+# Needed in test_falllback.py because it uses dict + string compare to make a virtual file structure
+def _normalize_path(path):
+    path = PurePath(path)
+    if path.is_absolute():
+        raise ValueError("Absolute paths are not supported in file simulation yet. ("
+                         + str(path) + ")")
+    if "." not in path.parts and ".." not in path.parts:
+        return "/".join(PurePath(path).parts)
+    else:
+        res_parts = []
+        length = len(path.parts)
+        i = 0
+        while i < length:
+            if path.parts[i] == ".":
+                i += 1
+            elif i < length - 1 and path.parts[i+1] == "..":
+                i += 2
+            else:
+                res_parts.append(path.parts[i])
+                i += 1
+        return "/".join(res_parts)
+
+
+def patch_files(files: dict):
+    """Decorate a function to simulate files ``files`` during the function.
+
+    The keys of ``files`` are file names and must use '/' for path separator.
+    The values are file contents. Directories or relative paths are not supported.
+    Example: ``{"en/one.txt": "One", "en/two.txt": "Two"}``
+
+    The implementation may be changed to match the mechanism used.
+    """
+    if files is None:
+        files = {}
+
+    def then(func):
+        @mock.patch("os.path.isfile", side_effect=lambda p: _normalize_path(p) in files)
+        @mock.patch("codecs.open", side_effect=lambda p, _, __: StringIO(files[_normalize_path(p)]))
+        @functools.wraps(func)  # Make ret look like func to later decorators
+        def ret(*args, **kwargs):
+            func(*args[:-2], **kwargs)
+        return ret
+    return then


### PR DESCRIPTION
`test_fallback.py` uses simple string compare (through dict) to simulate files. On Windows, paths are formed with `\` instead of `/`, which causes inconsistency in the string compare, producing the failures below. (Specifically, the `\`s were created by `os.path.join` in `FluentResourceLoader`.)

Without this fix, running `python -m unittest discover -s fluent.runtime` on Windows on df5ef402be3cf61f4a16e54e490e37e9cf276c05 produced the following failures: (Some folders in paths omitted)

```
....................................................................................................................................................E.F.F.D:\***\python-fluent\fluent.runtime\fluent\runtime\types.py:361: UserWarning: FluentDateType option hour12 is not yet supported
  warnings.warn(f"FluentDateType option {k} is not yet supported")
................s...............
======================================================================
ERROR: test_bundles (tests.test_fallback.TestLocalization.test_bundles)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "D:\***\Python\Python313\Lib\unittest\mock.py", line 1424, in patched
    return func(*newargs, **newkeywargs)
  File "D:\***\python-fluent\fluent.runtime\tests\test_fallback.py", line 34, in test_bundles
    bundle_de = next(bundles_gen)
StopIteration

======================================================================
FAIL: test_all_exist (tests.test_fallback.TestResourceLoader.test_all_exist)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "D:\***\Python\Python313\Lib\unittest\mock.py", line 1424, in patched
    return func(*newargs, **newkeywargs)
  File "D:\***\python-fluent\fluent.runtime\tests\test_fallback.py", line 64, in test_all_exist
    self.assertEqual(len(resources_list), 1)
    ~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^
AssertionError: 0 != 1

======================================================================
FAIL: test_one_exists (tests.test_fallback.TestResourceLoader.test_one_exists)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "D:\***\Python\Python313\Lib\unittest\mock.py", line 1424, in patched
    return func(*newargs, **newkeywargs)
  File "D:\***\python-fluent\fluent.runtime\tests\test_fallback.py", line 76, in test_one_exists
    self.assertEqual(len(resources_list), 1)
    ~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^
AssertionError: 0 != 1

----------------------------------------------------------------------
Ran 186 tests in 0.325s

FAILED (failures=2, errors=1, skipped=1)
```

Note: This pull request has lint errors, but I don't know how to fix them.