### PR TITLE
runtime: add attribute formatting functionality in FluentLocalization

### DIFF
--- a/fluent.runtime/docs/usage.rst
+++ b/fluent.runtime/docs/usage.rst
@@ -280,15 +280,16 @@ form input may have a value, but also a placeholder attribute, aria-label
 attribute, and maybe a title attribute.
 
 .. code-block:: python
+
     >>> l10n = DemoLocalization("""
-    ...     login-input = Predefined value
-    ...         .placeholder = { $email }
-    ...         .aria-label = Login input value
-    ...         .title = Type your login email
-    """)
+    ... login-input = Predefined value
+    ...     .placeholder = { $email }
+    ...     .aria-label = Login input value
+    ...     .title = Type your login email
+    ... """)
     >>> value, attributes = l10n.format_message(
-            "login-input", {"email": "email@example.com"}
-        )
+    ...     "login-input", {"email": "email@example.com"}
+    ... )
     >>> value
     'Predefined value'
     >>> attributes
@@ -297,9 +298,10 @@ attribute, and maybe a title attribute.
 You can also use the formatted message without unpacking it.
 
 .. code-block:: python
+
     >>> fmt_msg = l10n.format_message(
-            "login-input", {"email": "email@example.com"}
-        )
+    ...     "login-input", {"email": "email@example.com"}
+    ... )
     >>> fmt_msg.value
     'Predefined value'
     >>> fmt_msg.attributes

--- a/fluent.runtime/docs/usage.rst
+++ b/fluent.runtime/docs/usage.rst
@@ -275,21 +275,35 @@ above.
 Attributes
 ~~~~~~~~~~
 When rendering UI elements, it's handy to have a single translation that
-contains everything you need in one variable. For example, a Web
-Component confirm window with an OK button, a Cancel button, and a
-message.
+contains everything you need in one variable. For example, a HTML
+form input may have a value, but also a placeholder attribute, aria-label
+attribute, and maybe a title attribute.
 
 .. code-block:: python
     >>> l10n = DemoLocalization("""
-    ...     order-cancel-window = Are you sure you want to cancel the order #{ $order }?
-    ...         .ok = Yes
-    ...         .cancel = No
+    ...     login-input = Predefined value
+    ...         .placeholder = { $email }
+    ...         .aria-label = Login input value
+    ...         .title = Type your login email
     """)
-    >>> message, attributes = l10n.format_message("order-cancel-window", {'order': 123})
+    >>> message, attributes = l10n.format_message(
+            "login-input", {"placeholder": "email@example.com"}
+        )
     >>> message
-    'Are you sure you want to cancel the order #123?'
+    'Predefined value'
     >>> attributes
-    {'ok': 'Yes', 'cancel': 'No'}
+    {'placeholder': 'email@example.com', 'aria-label': 'Login input value', 'title': 'Type your login email'}
+  
+You can also use the formatted message without unpacking it.
+
+.. code-block:: python
+    >>> fmt_msg = l10n.format_message(
+            "login-input", {"placeholder": "email@example.com"}
+        )
+    >>> fmt_msg.message
+    'Predefined value'
+    >>> fmt_msg.attributes
+    {'placeholder': 'email@example.com', 'aria-label': 'Login input value', 'title': 'Type your login email'}
 
 Known limitations and bugs
 ~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/fluent.runtime/docs/usage.rst
+++ b/fluent.runtime/docs/usage.rst
@@ -272,6 +272,25 @@ instances to indicate an error or missing data. Otherwise they should
 return unicode strings, or instances of a ``FluentType`` subclass as
 above.
 
+Attributes
+~~~~~~~~~~
+When rendering UI elements, it's handy to have a single translation that
+contains everything you need in one variable. For example, a Web
+Component confirm window with an OK button, a Cancel button, and a
+message.
+
+.. code-block:: python
+    >>> l10n = DemoLocalization("""
+    ...     order-cancel-window = Are you sure you want to cancel the order #{ $order }?
+    ...         .ok = Yes
+    ...         .cancel = No
+    """)
+    >>> message, attributes = l10n.format_message("order-cancel-window", {'order': 123})
+    >>> message
+    'Are you sure you want to cancel the order #123?'
+    >>> attributes
+    {'ok': 'Yes', 'cancel': 'No'}
+
 Known limitations and bugs
 ~~~~~~~~~~~~~~~~~~~~~~~~~~
 

--- a/fluent.runtime/docs/usage.rst
+++ b/fluent.runtime/docs/usage.rst
@@ -286,10 +286,10 @@ attribute, and maybe a title attribute.
     ...         .aria-label = Login input value
     ...         .title = Type your login email
     """)
-    >>> message, attributes = l10n.format_message(
-            "login-input", {"placeholder": "email@example.com"}
+    >>> value, attributes = l10n.format_message(
+            "login-input", {"email": "email@example.com"}
         )
-    >>> message
+    >>> value
     'Predefined value'
     >>> attributes
     {'placeholder': 'email@example.com', 'aria-label': 'Login input value', 'title': 'Type your login email'}
@@ -298,9 +298,9 @@ You can also use the formatted message without unpacking it.
 
 .. code-block:: python
     >>> fmt_msg = l10n.format_message(
-            "login-input", {"placeholder": "email@example.com"}
+            "login-input", {"email": "email@example.com"}
         )
-    >>> fmt_msg.message
+    >>> fmt_msg.value
     'Predefined value'
     >>> fmt_msg.attributes
     {'placeholder': 'email@example.com', 'aria-label': 'Login input value', 'title': 'Type your login email'}

--- a/fluent.runtime/fluent/runtime/__init__.py
+++ b/fluent.runtime/fluent/runtime/__init__.py
@@ -2,7 +2,7 @@ from fluent.syntax import FluentParser
 from fluent.syntax.ast import Resource
 
 from .bundle import FluentBundle
-from .fallback import AbstractResourceLoader, FluentLocalization, FluentResourceLoader
+from .fallback import AbstractResourceLoader, FluentLocalization, FluentResourceLoader, FormattedMessage
 
 __all__ = [
     "FluentLocalization",
@@ -10,6 +10,7 @@ __all__ = [
     "FluentResourceLoader",
     "FluentResource",
     "FluentBundle",
+    "FormattedMessage",
 ]
 
 

--- a/fluent.runtime/fluent/runtime/fallback.py
+++ b/fluent.runtime/fluent/runtime/fallback.py
@@ -61,25 +61,21 @@ class FluentLocalization:
             if not bundle.has_message(msg_id):
                 continue
             msg = bundle.get_message(msg_id)
-            formatted_attrs = None
-            if msg.attributes:
-                formatted_attrs = {
-                    attr: cast(
-                        str,
-                        bundle.format_pattern(msg.attributes[attr], args)[0],
-                    )
-                    for attr in msg.attributes
-                }
-            if not msg.value and formatted_attrs is None:
-                continue
-            elif not msg.value and formatted_attrs:
+            formatted_attrs = {
+                attr: cast(
+                    str,
+                    bundle.format_pattern(msg.attributes[attr], args)[0],
+                )
+                for attr in msg.attributes
+            }
+            if not msg.value:
                 val = None
             else:
                 val, _errors = bundle.format_pattern(msg.value, args)
             return FormattedMessage(
                 # Never FluentNone when format_pattern called externally
                 cast(str, val),
-                formatted_attrs if formatted_attrs else {},
+                formatted_attrs,
             )
         return FormattedMessage(msg_id, {})
 

--- a/fluent.runtime/fluent/runtime/fallback.py
+++ b/fluent.runtime/fluent/runtime/fallback.py
@@ -62,7 +62,7 @@ class FluentLocalization:
             for bundle in self._bundles()
             if bundle.has_message(msg_id)
         ), (None, None))
-        if not msg:
+        if not bundle or not msg:
             return FormattedMessage(msg_id, {})
         formatted_attrs = {
             attr: cast(
@@ -89,7 +89,7 @@ class FluentLocalization:
             for bundle in self._bundles()
             if bundle.has_message(msg_id)
         ), (None, None))
-        if not msg or not msg.value:
+        if not bundle or not msg or not msg.value:
             return msg_id
         val, _errors = bundle.format_pattern(msg.value, args)
         return cast(

--- a/fluent.runtime/tests/test_fallback.py
+++ b/fluent.runtime/tests/test_fallback.py
@@ -12,11 +12,25 @@ class TestLocalization(unittest.TestCase):
         self.assertTrue(callable(l10n.format_value))
 
     @patch_files({
-        "de/one.ftl": "one = in German",
-        "de/two.ftl": "two = in German",
-        "fr/two.ftl": "three = in French",
-        "en/one.ftl": "four = exists",
-        "en/two.ftl": "five = exists",
+        "de/one.ftl": """one = in German
+            .foo = one in German
+        """,
+        "de/two.ftl": """two = in German
+            .foo = two in German
+        """,
+        "fr/two.ftl": """three = in French
+            .foo = three in French
+        """,
+        "en/one.ftl": """four = exists
+            .foo = four in English
+        """,
+        "en/two.ftl": """
+five = exists
+    .foo = five in English
+bar =
+    .foo = bar in English
+baz = baz in English
+        """,
     })
     def test_bundles(self):
         l10n = FluentLocalization(
@@ -39,6 +53,41 @@ class TestLocalization(unittest.TestCase):
         self.assertEqual(l10n.format_value("three"), "in French")
         self.assertEqual(l10n.format_value("four"), "exists")
         self.assertEqual(l10n.format_value("five"), "exists")
+        self.assertEqual(l10n.format_value("bar"), "bar")
+        self.assertEqual(l10n.format_value("baz"), "baz in English")
+        self.assertEqual(l10n.format_value("not-exists"), "not-exists")
+        self.assertEqual(
+            tuple(l10n.format_message("one")),
+            ("in German", {"foo": "one in German"}),
+        )
+        self.assertEqual(
+            tuple(l10n.format_message("two")),
+            ("in German", {"foo": "two in German"}),
+        )
+        self.assertEqual(
+            tuple(l10n.format_message("three")),
+            ("in French", {"foo": "three in French"}),
+        )
+        self.assertEqual(
+            tuple(l10n.format_message("four")),
+            ("exists", {"foo": "four in English"}),
+        )
+        self.assertEqual(
+            tuple(l10n.format_message("five")),
+            ("exists", {"foo": "five in English"}),
+        )
+        self.assertEqual(
+            tuple(l10n.format_message("bar")),
+            (None, {"foo": "bar in English"}),
+        )
+        self.assertEqual(
+            tuple(l10n.format_message("baz")),
+            ("baz in English", {}),
+        )
+        self.assertEqual(
+            tuple(l10n.format_message("not-exists")),
+            ("not-exists", {}),
+        )
 
 
 class TestResourceLoader(unittest.TestCase):


### PR DESCRIPTION
Resolving issue with accessing message attributes via FluentLocalization.format_value("message.attribute")

Connected issues:
https://github.com/projectfluent/python-fluent/issues/209